### PR TITLE
HXP.rand() returns zero

### DIFF
--- a/src/com/haxepunk/HXP.hx
+++ b/src/com/haxepunk/HXP.hx
@@ -488,8 +488,8 @@ class HXP
 	public static var random(getRandom, null):Float;
 	private static function getRandom():Float
 	{
-		_seed = (_seed * 16807) % 2147483647;
-		return _seed / 2147483647;
+		_seed = Std.int((_seed * 16807.0) % 2147483647.0);
+		return _seed / 2147483647.0;
 	}
 	
 	/**
@@ -499,8 +499,8 @@ class HXP
 	 */
 	public static function rand(amount:Int):Int
 	{
-		_seed = (_seed * 16807) % 2147483647;
-		return Std.int(_seed / 2147483647) * amount;
+		_seed = Std.int((_seed * 16807.0) % 2147483647.0);
+		return Std.int((_seed / 2147483647.0) * amount);
 	}
 	
 	/**


### PR DESCRIPTION
`HXP.rand(n)` always returns zero right now. It casts the 0.0 to 1.0 value as an int before scaling.

The constant values in these functions must also be treated as floats instead of ints (as was done for `setRandomSeed`), or you get invalid negative values returned from the methods.
