### PR TITLE
Allow MultiVarTweens to work on properties that are 0.

### DIFF
--- a/src/com/haxepunk/tweens/misc/MultiVarTween.hx
+++ b/src/com/haxepunk/tweens/misc/MultiVarTween.hx
@@ -43,7 +43,6 @@ class MultiVarTween extends Tween
 		{
 			if (!Reflect.hasField(object, p)) throw "The Object does not have the property\"" + p + "\", or it is not accessible.";
 			var a:Float = Reflect.field(object, p);
-			if (a == 0) throw "The property \"" + p + "\" is not numeric.";
 			_vars.push(p);
 			_start.push(a);
 			_range.push(Reflect.field(values, p) - a);


### PR DESCRIPTION
I assume this was a bug caused by automatic conversion of FlashPunk
code, or something similar.

I haven't been able to test this properly, because haxelib doesn't seem
to like the zip files that ant creates; but I've tested it in a project
of my own. (And it's a delete-one-line change.)
