### PR TITLE
Issue: You have to call addGraphic twice the first time

### DIFF
--- a/src/com/haxepunk/Entity.hx
+++ b/src/com/haxepunk/Entity.hx
@@ -569,6 +569,7 @@ class Entity extends Tweener
 		{
 			var list:Graphiclist = new Graphiclist();
 			if (graphic != null) list.add(graphic);
+			list.add(g);
 			graphic = list;
 		}
 		return g;


### PR DESCRIPTION
I encountered following issue: If you call Entity:addGraphic when the 'graphic'-member isn't a graphicsList yet, the 'graphic'-member only gets casted to a graphicsList without adding the actual graphic.

This happens in the following section:

``` as3
    public function addGraphic(g:Graphic):Graphic
    {
        if (Std.is(graphic, Graphiclist)) cast(graphic, Graphiclist).add(g);
        else
        {
            var list:Graphiclist = new Graphiclist();
            if (graphic != null) list.add(graphic);
            graphic = list;

        }
        return g;
    }
```

The attached code fixes the problem.

I looked at the original FlashPunk source and I am not really sure why this bug doesn't happen there..
