### PR TITLE
Fixed: Entities can only be added to the world once per update.

### DIFF
--- a/src/com/haxepunk/World.hx
+++ b/src/com/haxepunk/World.hx
@@ -1044,6 +1044,7 @@ class World extends Tweener
 			for (e in _add)
 			{
 				fe = e;
+				if (fe._world != null) continue;
 				fe._added = true;
 				fe._world = this;
 				addUpdate(e);


### PR DESCRIPTION
If an entity were to be added like:

var e:Entity = new Entity();
add(e);
add(e);

An endless loop was caused because _updateNext in that Entity would
reference itself.
