### PR TITLE
Correctly handle reduced Text size

### DIFF
--- a/src/com/haxepunk/graphics/Text.hx
+++ b/src/com/haxepunk/graphics/Text.hx
@@ -98,11 +98,11 @@ class Text extends Image
 			_bufferRect.height = textHeight;
 		}
 
-		if (textWidth > _source.width || textHeight > _source.height)
+		if (textWidth != _source.width || textHeight != _source.height)
 		{
 			_source = HXP.createBitmap(
-				Std.int(Math.max(textWidth, _source.width)),
-				Std.int(Math.max(textHeight, _source.height)),
+				textWidth,
+				textHeight,
 				true);
 
 			_sourceRect = _source.rect;


### PR DESCRIPTION
Fixed another problem on `Text`, which is when a `Text` is given a shorter `text`, the `width` does not reflect the new size because `_source` is not changed:

``` haxe
import com.haxepunk.*;
import com.haxepunk.graphics.*;

class TestWorld extends World {
    override public function begin():Void {
        super.begin();

        var text = new Text("TestingTestingTestingTesting", { resizable: true });
        trace(text.textWidth + " " + text.textHeight + " " + text.width + " " + text.height); //196 16 196 16
        text.text = "Testing";
        trace(text.textWidth + " " + text.textHeight + " " + text.width + " " + text.height); //52 16 196 16 :(

        addGraphic(Image.createRect(text.textWidth, text.textHeight, 0xFF0000));
        addGraphic(text);
    }
}

class Main extends Engine {
    public function new():Void {
        super();
        HXP.world = new TestWorld();
    }

    static public function main():Void {
        nme.Lib.current.addChild(new Main());
    }
}
```

I think it is time to create a proper unit test. It is because the recent improvements of HaxePunk broke quite a few things. I am still having another seemly unrelated problem on Android, which I am going to investigate...
