### PR TITLE
bugfix: scale factors on Images no longer modify x/y position when using texture atlases

### DIFF
--- a/src/com/haxepunk/graphics/Image.hx
+++ b/src/com/haxepunk/graphics/Image.hx
@@ -196,7 +196,8 @@ class Image extends Graphic
 			var sx = HXP.screen.fullScaleX * scale * scaleX,
 				sy = HXP.screen.fullScaleY * scale * scaleY;
 
-			_region.draw(_point.x * sx, _point.y * sy,
+			_region.draw(_point.x * HXP.screen.fullScaleX,
+				_point.y * HXP.screen.fullScaleY,
 				layer, sx * (_flipped ? -1 : 1), sy, angle,
 				HXP.getRed(_color)/255, HXP.getGreen(_color)/255, HXP.getBlue(_color)/255, _alpha);
 		}


### PR DESCRIPTION
I left in the `fullScaleX` and `fullScaleY` like we talked about although I haven't tested them with the use case that caused you to add it in the first place.
