### PR TITLE
Neko crash on new Text

### DIFF
--- a/src/com/haxepunk/Entity.hx
+++ b/src/com/haxepunk/Entity.hx
@@ -101,12 +101,12 @@ class Entity extends Tweener
 		_point = HXP.point;
 		_camera = HXP.point2;
 
+		layer = HXP.BASELAYER;
+
 		if (graphic != null) this.graphic = graphic;
 		if (mask != null) this.mask = mask;
 		HITBOX.assignTo(this);
 		_class = Type.getClassName(Type.getClass(this));
-
-		layer = HXP.BASELAYER;
 	}
 
 	/**


### PR DESCRIPTION
Thanks Matt for the fast turnaround. Latest commit fixes the native target issues I reported [url=/index.php?topic=316.0]here[/url], however Neko now crashes at Text:166. I've traced this back to Entity.new:104, if a graphic is passed as a new Entity parameter, it tries to assign the graphic before the _layer is given a default value . Moving the default layer set back a few lines fixes the issue.

This is my first pull request! Please throw a parade. I expect confetti. Possibly Rip Taylor as well. ;)
