### PR TITLE
Fix class cast error when reusing bitmap for Atlas then TileAtlas

### DIFF
--- a/src/com/haxepunk/graphics/atlas/TileAtlas.hx
+++ b/src/com/haxepunk/graphics/atlas/TileAtlas.hx
@@ -30,7 +30,17 @@ class TileAtlas extends Atlas
 		{
 			if (Atlas._atlasPool.exists(source))
 			{
-				atlas = cast(Atlas._atlasPool.get(source), TileAtlas);
+				var poolEntry:Atlas = Atlas._atlasPool.get(source);
+				if(Std.is(poolEntry, TileAtlas))
+				{
+					atlas = cast(poolEntry, TileAtlas);
+				}
+				else
+				{
+					atlas = new TileAtlas(HXP.getBitmap(source), tileWidth, tileHeight);
+					atlas._name = poolEntry._name;
+					Atlas._atlasPool.set(source, atlas);
+				} 
 				atlas._refCount += 1;
 			}
 			else


### PR DESCRIPTION
On CPP targets, add an Image (say, with a clip rect), then add a Tilemap using the same bitmap. This throws a class cast error in TileAtlas:

``` Haxe
if (Atlas._atlasPool.exists(source))
{
   atlas = cast(Atlas._atlasPool.get(source), TileAtlas);
   atlas._refCount += 1;
}
```

If you switch it so the Tilemap is created before the Image, the problem goes away. The reason for this seems to be that _atlasPool holds both Atlas and its child, TileAtlas. TileAtlas assumes that the existing entry in this pool is a TileAtlas, and tries to cast an Atlas to a TileAtlas. Not sure if this is the best solution, but what I did was convert the Atlas on the spot to a TileAtlas.
