### PR TITLE
Fix:  World.mouseX/Y should be relative to the world's camera.

### DIFF
--- a/src/com/haxepunk/Scene.hx
+++ b/src/com/haxepunk/Scene.hx
@@ -138,7 +138,7 @@ class Scene extends Tweener
 	public var mouseX(get_mouseX, null):Int;
 	private inline function get_mouseX():Int
 	{
-		return Std.int(HXP.screen.mouseX + HXP.camera.x);
+		return Std.int(HXP.screen.mouseX + camera.x);
 	}
 
 	/**
@@ -147,7 +147,7 @@ class Scene extends Tweener
 	public var mouseY(get_mouseY, null):Int;
 	private inline function get_mouseY():Int
 	{
-		return Std.int(HXP.screen.mouseY + HXP.camera.y);
+		return Std.int(HXP.screen.mouseY + camera.y);
 	}
 
 	/**


### PR DESCRIPTION
HXP.camera is used mainly as a fallback camera for rendering an entity
that is not added to a world in FP.
