### PR TITLE
fixed memory leak for non flash targets

### DIFF
--- a/com/haxepunk/graphics/Canvas.hx
+++ b/com/haxepunk/graphics/Canvas.hx
@@ -40,28 +40,29 @@ class Canvas extends Graphic
 		_width = width;
 		_height = height;
 		
-#if flash
-		_refWidth = Math.ceil(width / _maxWidth);
-		_refHeight = Math.ceil(height / _maxHeight);
-		_ref = HXP.createBitmap(_refWidth, _refHeight);
-		var x:Int = 0, y:Int = 0, w:Int, h:Int, i:Int = 0,
-			ww:Int = _width % _maxWidth,
-			hh:Int = _height % _maxHeight;
-		if (ww == 0) ww = _maxWidth;
-		if (hh == 0) hh = _maxHeight;
-		while (y < _refHeight)
+		if (HXP.renderMode.has(RenderMode.BUFFER))
 		{
-			h = y < _refHeight - 1 ? _maxHeight : hh;
-			while (x < _refWidth)
+			_refWidth = Math.ceil(width / _maxWidth);
+			_refHeight = Math.ceil(height / _maxHeight);
+			_ref = HXP.createBitmap(_refWidth, _refHeight);
+			var x:Int = 0, y:Int = 0, w:Int, h:Int, i:Int = 0,
+				ww:Int = _width % _maxWidth,
+				hh:Int = _height % _maxHeight;
+			if (ww == 0) ww = _maxWidth;
+			if (hh == 0) hh = _maxHeight;
+			while (y < _refHeight)
 			{
-				w = x < _refWidth - 1 ? _maxWidth : ww;
-				_ref.setPixel(x, y, i);
-				_buffers[i] = HXP.createBitmap(w, h, true);
-				i ++; x ++;
+				h = y < _refHeight - 1 ? _maxHeight : hh;
+				while (x < _refWidth)
+				{
+					w = x < _refWidth - 1 ? _maxWidth : ww;
+					_ref.setPixel(x, y, i);
+					_buffers[i] = HXP.createBitmap(w, h, true);
+					i ++; x ++;
+				}
+				x = 0; y ++;
 			}
-			x = 0; y ++;
 		}
-#end
 	}
 
 	/** @private Renders the canvas. */


### PR DESCRIPTION
It is not a real leak, but on non flash targets the canvas buffer allocates more memory then needed.

The buffer on [Canvas.hx l.57](https://github.com/HaxePunk/HaxePunk/blob/e992a0ee3540ffe70e91cc3c0a08728da778bfda/com/haxepunk/graphics/Canvas.hx#L57) is used for rendering Canvas and Tilemaps at flash target only but is filled on every target what, at least, is a problem on mobile devices. 

This patch has dropped the memory from ~700mb to 21mb on our project.
