### PR TITLE
Add an option to disable the capture of Log.trace in the console

### DIFF
--- a/com/haxepunk/debug/Console.hx
+++ b/com/haxepunk/debug/Console.hx
@@ -89,8 +89,6 @@ class Console
 		WATCH_LIST.add("x");
 		WATCH_LIST.add("y");
 		WATCH_LIST.add("layer");
-		
-		captureTrace = true;
 	}
 
 	private function traceLog(v:Dynamic, ?infos:PosInfos)
@@ -149,11 +147,13 @@ class Console
 
 	/**
 	 * Enables the console.
+	 * @param   value           Set the console enabled or disabled.
+	 * @param   captureTrace    Option to capture trace in HaxePunk.
 	 */
-	public function enable()
+	public function enable(value:Bool=true, captureTrace:Bool=true)
 	{
-		// Quit if the console is already enabled.
-		if (_enabled) return;
+		// Quit if the console is already in the same state as value (enabled or disabled).
+		if (_enabled == value) return;
 
 		// load assets based on embedding method
 		try
@@ -1024,15 +1024,6 @@ class Console
 
 	public var height(get_height, null):Int;
 	private function get_height():Int { return HXP.windowHeight; }
-
-	/**
-	 * Whether the HaxePunk's console should capture calls to `trace()` and display it in the in-game console or not (true by default).
-	 * Have to be set before calling `HXP.console.enable()`.
-	 */
-	public var captureTrace(default, set_captureTrace):Bool;
-	private function set_captureTrace(value:Bool):Bool {
-		return captureTrace = value;
-	}
 
 	// Console state information.
 	private var _enabled:Bool;


### PR DESCRIPTION
Hi,

I don't know if I'm the only one, but I really don't like that HaxePunk is capturing calls to trace(); I prefer to have an external output where I can search, copy, and read when the game is closed. So every time I create a new project I add HaxePunk to the source and remove the line capturing traces. 
Well, I added an option to change this behavior and hopefully you'll accept it. If you have remarks, let me now and I'll make some changes.
