### PR TITLE
Fix debug renderEntities when entity's scroll is != 1

### DIFF
--- a/com/haxepunk/debug/Console.hx
+++ b/com/haxepunk/debug/Console.hx
@@ -740,6 +740,9 @@ class Console
 			g.clear();
 			for (e in SCREEN_LIST)
 			{
+				var graphicScrollX = e.graphic != null ? e.graphic.scrollX : 1;
+				var graphicScrollY = e.graphic != null ? e.graphic.scrollY : 1;
+				
 				// If the Entity is not selected.
 				if (Lambda.indexOf(SELECT_LIST, e) < 0)
 				{
@@ -747,7 +750,7 @@ class Console
 					if (e.width != 0 && e.height != 0)
 					{
 						g.lineStyle(1, 0xFF0000);
-						g.drawRect((e.x - e.originX - HXP.camera.x) * sx, (e.y - e.originY - HXP.camera.y) * sy, e.width * sx, e.height * sy);
+						g.drawRect((e.x - e.originX - HXP.camera.x * graphicScrollX) * sx, (e.y - e.originY - HXP.camera.y * graphicScrollY) * sy, e.width * sx, e.height * sy);
 
 						if (e.mask != null)
 						{
@@ -756,7 +759,7 @@ class Console
 						}
 					}
 					g.lineStyle(1, 0x00FF00);
-					g.drawRect((e.x - HXP.camera.x) * sx - 3, (e.y - HXP.camera.y) * sy - 3, 6, 6);
+					g.drawRect((e.x - HXP.camera.x * graphicScrollX) * sx - 3, (e.y - HXP.camera.y * graphicScrollY) * sy - 3, 6, 6);
 				}
 				else
 				{
@@ -764,7 +767,7 @@ class Console
 					if (e.width != 0 && e.height != 0)
 					{
 						g.lineStyle(1, 0xFFFFFF);
-						g.drawRect((e.x - e.originX - HXP.camera.x) * sx, (e.y - e.originY - HXP.camera.y) * sy, e.width * sx, e.height * sy);
+						g.drawRect((e.x - e.originX - HXP.camera.x * graphicScrollX) * sx, (e.y - e.originY - HXP.camera.y * graphicScrollY) * sy, e.width * sx, e.height * sy);
 
 						if (e.mask != null)
 						{
@@ -773,7 +776,7 @@ class Console
 						}
 					}
 					g.lineStyle(1, 0xFFFFFF);
-					g.drawRect((e.x - HXP.camera.x) * sx - 3, (e.y - HXP.camera.y) * sy - 3, 6, 6);
+					g.drawRect((e.x - HXP.camera.x * graphicScrollX) * sx - 3, (e.y - HXP.camera.y * graphicScrollY) * sy - 3, 6, 6);
 				}
 			}
 		}


### PR DESCRIPTION
Fix the hitbox's rectangle in debug mode when the default value of an entity's scroll has been changed. Without it, the debug rectangle has a wrong offset.

Here's an entity example if you want to quickly see it yourself :

```
package ;

import com.haxepunk.Entity;
import com.haxepunk.graphics.Image;
import nme.display.BitmapData;

class EntityExample extends Entity
{
    public function new(x:Float=0, y:Float=0) 
    {
        super(x, y);
        graphic = new Image(new BitmapData(32, 32));
        setHitbox(32, 32);
        graphic.scrollX = 0;
        graphic.scrollY = 0;
    }
}
```
