### PR TITLE
Several fixes (Rotated AtlasRegions, Text, TextureAtlas)

### DIFF
--- a/com/haxepunk/graphics/Image.hx
+++ b/com/haxepunk/graphics/Image.hx
@@ -401,13 +401,13 @@ class Image extends Graphic
 	 * Width of the image.
 	 */
 	public var width(get_width, never):Int;
-	private function get_width():Int { return Std.int(_blit ? _bufferRect.width : _region.width); }
+	private function get_width():Int { return Std.int(_blit ? _bufferRect.width : (!_region.rotated ? _region.width : _region.height)); }
 
 	/**
 	 * Height of the image.
 	 */
 	public var height(get_height, never):Int;
-	private function get_height():Int { return Std.int(_blit ? _bufferRect.height : _region.height); }
+	private function get_height():Int { return Std.int(_blit ? _bufferRect.height : (!_region.rotated ? _region.height : _region.width)); }
 
 	/**
 	 * The scaled width of the image.

--- a/com/haxepunk/graphics/Text.hx
+++ b/com/haxepunk/graphics/Text.hx
@@ -157,6 +157,7 @@ class Text extends Image
 		if (_parent != null)
 		{
 			_parent.removeChild(_field);
+			_parent = null;
 		}
 	}
 

--- a/com/haxepunk/graphics/atlas/AtlasRegion.hx
+++ b/com/haxepunk/graphics/atlas/AtlasRegion.hx
@@ -59,7 +59,7 @@ class AtlasRegion
 		scaleX:Float=1, scaleY:Float=1, angle:Float=0,
 		red:Float=1, green:Float=1, blue:Float=1, alpha:Float=1)
 	{
-		if (rotated) angle = angle - 90;
+		if (rotated) angle = angle + 90;
 		parent.prepareTile(tileIndex, x, y, layer, scaleX, scaleY, angle, red, green, blue, alpha);
 	}
 

--- a/com/haxepunk/graphics/atlas/TextureAtlas.hx
+++ b/com/haxepunk/graphics/atlas/TextureAtlas.hx
@@ -19,7 +19,8 @@ class TextureAtlas extends Atlas
 	}
 
 	/**
-	 * Loads a TexturePacker xml file and generates all tile regions
+	 * Loads a TexturePacker xml file and generates all tile regions.
+	 * Uses the Generic XML exporter format from Texture Packer.
 	 * @param file the TexturePacker file to load
 	 * @return a TextureAtlas with all packed images defined as regions
 	 */


### PR DESCRIPTION
Fixed: Rotated atlas regions were rotated the wrong way.
Fixed: Images reported the wrong width and height when it's source was a
rotated atlas region.
Fixed: When text removed itself from it's parent, _parent should be set
to null.
Clarified some documentation for TextureAtlas.loadTexturePacker.

BWAHAHAHAHA!  Thanks for the help man!
