### PR TITLE
Small change to make spritemaps animate the same in fixed timestep mode

### DIFF
--- a/com/haxepunk/graphics/Spritemap.hx
+++ b/com/haxepunk/graphics/Spritemap.hx
@@ -115,7 +115,7 @@ class Spritemap extends Image
 	{
 		if (_anim != null && !complete)
 		{
-			_timer += (HXP.fixed ? _anim.frameRate : _anim.frameRate * HXP.elapsed) * rate;
+			_timer += (HXP.fixed ? _anim.frameRate / HXP.frameRate : _anim.frameRate * HXP.elapsed) * rate;
 			if (_timer >= 1)
 			{
 				while (_timer >= 1)


### PR DESCRIPTION
Right now spritemaps animate at a different rate in fixed timestep mode. To make them animate similarly to in non-fixed timestep mode, you have to give animations very low framerate values (<1). This change makes the timer in fixed timestep mode work similar to how it works in non-fixed timestep mode by dividing the value of _anim.frameRate by HXP.frameRate.

Also, see this thread: http://forum.haxepunk.com/index.php?topic=400.msg1106
