### PR TITLE
Allow setHitboxTo for all targets

### DIFF
--- a/com/haxepunk/Entity.hx
+++ b/com/haxepunk/Entity.hx
@@ -650,7 +650,6 @@ class Entity extends Tweener
 	 */
 	public function setHitboxTo(o:Dynamic)
 	{
-#if (flash || android)
 		width = Reflect.getProperty(o, "width");
 		height = Reflect.getProperty(o, "height");
 
@@ -667,9 +666,6 @@ class Entity extends Tweener
 			originX = Reflect.getProperty(o, "originX");
 			originY = Reflect.getProperty(o, "originY");
 		}
-#else
-		HXP.log("setHitboxTo not supported on this platform");
-#end
 	}
 
 	/**


### PR DESCRIPTION
I removed the limitation on setHitboxTo,
Reflect.getProperty is now available on all targets.

I tested on linux targets flash, cpp and neko. 
