### PR TITLE
Changing RenderMode for html5 target to Buffer.

### DIFF
--- a/com/haxepunk/Engine.hx
+++ b/com/haxepunk/Engine.hx
@@ -69,7 +69,7 @@ class Engine extends Sprite
 		}
 		else
 		{
-			HXP.renderMode.set(#if flash RenderMode.BUFFER #else RenderMode.HARDWARE #end);
+			HXP.renderMode.set(#if (flash || js) RenderMode.BUFFER #else RenderMode.HARDWARE #end);
 		}
 
 		// global game objects


### PR DESCRIPTION
Using the Rendermode.Buffer with the html5 target fix color and display issues.
For instance tilemaps don't display anything in hardware/html5.
