### PR TITLE
Destroy old graphic when changed.

### DIFF
--- a/com/haxepunk/Entity.hx
+++ b/com/haxepunk/Entity.hx
@@ -577,7 +577,11 @@ class Entity extends Tweener
 	private function set_graphic(value:Graphic):Graphic
 	{
 		if (_graphic == value) return value;
-		if (_graphic != null) _graphic.setEntity(null);
+		if (_graphic != null) 
+		{
+			_graphic.setEntity(null);
+			_graphic.destroy();
+		}
 		if (value != null)
 		{
 			value.layer = _layer;


### PR DESCRIPTION
Fix the issue https://github.com/HaxePunk/HaxePunk/issues/95,
when you update the graphic of an Entity instead of removing the Entity graphic.destroy() wasn't called,
and so the text wasn't removed from the screen on native.
