### PR TITLE
fix canvas render on native

### DIFF
--- a/com/haxepunk/graphics/Canvas.hx
+++ b/com/haxepunk/graphics/Canvas.hx
@@ -90,7 +90,12 @@ class Canvas extends Graphic
 					_matrix.ty = _point.y;
 					target.draw(buffer, _matrix, _tint, blend);
 				}
-				else target.copyPixels(buffer, _rect, _point, null, null, true);
+				else
+				{
+					_rect.width = buffer.width;
+					_rect.height = buffer.height;
+					target.copyPixels(buffer, _rect, _point, null, null, true);
+				}
 				_point.x += _maxWidth;
 				xx ++;
 			}


### PR DESCRIPTION
On native mac at least, drawing to a rect bigger than the original buffer, render the image multiple times. This fixes it.
