### PR TITLE
Fixed invisible particles

### DIFF
--- a/com/haxepunk/graphics/ParticleType.hx
+++ b/com/haxepunk/graphics/ParticleType.hx
@@ -34,10 +34,6 @@ class ParticleType
         _gravity  = _gravityRange  = 0;
         _duration = _durationRange = 0;
         _distance = _distanceRange = 0;
-        _alpha    = _alphaRange    = 0;
-
-        _red = _green = _blue = 1;
-        _redRange = _greenRange = _blueRange = 0;
 	}
 
 	/**


### PR DESCRIPTION
`_red, _green, _blue, _alpha` and their range are already declared in line 25f.

Because of `_alpha = 0` particles on cpp where invisible.
