### PR TITLE
Fix for text width/height ignored/changed to 100 in hardware rendering.

### DIFF
--- a/com/haxepunk/graphics/Text.hx
+++ b/com/haxepunk/graphics/Text.hx
@@ -86,8 +86,8 @@ class Text extends Image
 		if (HXP.renderMode.has(RenderMode.HARDWARE))
 		{
 			HXP.rect.x = HXP.rect.y = 0;
-			HXP.rect.width = _field.width;
-			HXP.rect.height = _field.height;
+			_field.width = HXP.rect.width = width;
+			_field.height = HXP.rect.height = height;
 			source = new AtlasRegion(null, 0, HXP.rect);
 			_blit = false;
 		}


### PR DESCRIPTION
Create a Text object with word wrap on and set a large Text width. This runs fine on Flash, but on CPP targets, the line wraps much sooner. In fact, the call to _field.textWidth returns a curious 100.

I believe this this fails in CPP because Flash.text.TextField uses 100x100 as the default size, and hardware rendering never sets the _field dimensions when a size is passed in. In Flash, updateBuffer sets the _field.width to match the buffer size. The same does not happen for hardware render using the atlas region. This change assigns the _field dimensions in the constructor for hardware rendering.

Possibly it would be better to handle the CPP _field sizing in updateBuffer too, I'm not sure, but this made text sizing work in CPP, at least in my app.
