### PR TITLE
Text object wraps at 100 pixels instead of specified width / dimensions corrupted by updateBuffer()

### DIFF
--- a/com/haxepunk/graphics/Text.hx
+++ b/com/haxepunk/graphics/Text.hx
@@ -41,6 +41,8 @@ class Text extends Image
 	public var resizable:Bool;
 	public var textWidth(default, null):Int;
 	public var textHeight(default, null):Int;
+	public var autoWidth:Bool = false;
+	public var autoHeight:Bool = false;
 
 	/**
 	 * Constructor.
@@ -79,15 +81,23 @@ class Text extends Image
 
 		resizable = options.resizable;
 
-		if (width == 0) width = Std.int(_field.textWidth + 4);
-		if (height == 0) height = Std.int(_field.textHeight + 4);
+		if (width == 0)
+		{
+			width = Std.int(_field.textWidth + 4);
+			autoWidth = true;
+		}
+		if (height == 0)
+		{
+			height = Std.int(_field.textHeight + 4);
+			autoHeight = true;
+		}
 
 		var source:Dynamic;
 		if (HXP.renderMode.has(RenderMode.HARDWARE))
 		{
 			HXP.rect.x = HXP.rect.y = 0;
-			_field.width = HXP.rect.width = width;
-			_field.height = HXP.rect.height = height;
+			_field.width = HXP.rect.width = textWidth = width;
+			_field.height = HXP.rect.height = textHeight = height;
 			source = new AtlasRegion(null, 0, HXP.rect);
 			_blit = false;
 		}
@@ -110,8 +120,11 @@ class Text extends Image
 		_field.setTextFormat(_format);
 
 		if (_blit) _field.width = _bufferRect.width;
-		_field.width = textWidth = Math.ceil(_field.textWidth + 4);
-		_field.height = textHeight = Math.ceil(_field.textHeight + 4);
+
+		if(autoWidth)
+			_field.width = textWidth = Math.ceil(_field.textWidth + 4);
+		if(autoHeight)
+			_field.height = textHeight = Math.ceil(_field.textHeight + 4);
 
 		if (_blit)
 		{


### PR DESCRIPTION
Create a Text object with word wrap on, center alignment, a large text string, and set a Text width of say 300. This runs fine on Flash, but on CPP targets, the line wraps much sooner. In fact, the call to _field.textWidth returns a curious 100. I believe this this fails in CPP because Flash.text.TextField uses 100x100 as the default size, and hardware rendering never sets the _field dimensions when a size is passed in. In Flash, updateBuffer sets the _field.width to match the buffer size. The same does not happen for hardware render using the atlas region. The first commit change assigns the _field dimensions in the constructor for hardware rendering.

Switching to a smaller text string, one that does not cause wrapping, seems to make the alignment go back to LEFT. What's happening is in updateBuffer() the TextField's width is reset to the actual rendered width of the TextField. The second commit adds autoWidth and autoHeight variables, which are only set/checked when the corresponding dimension is passed in as 0, which fixed centering in my test cases.
