### PR TITLE
Fixing Spritemap initialization bug on Linux64 target

### DIFF
--- a/com/haxepunk/graphics/Spritemap.hx
+++ b/com/haxepunk/graphics/Spritemap.hx
@@ -96,11 +96,12 @@ class Spritemap extends Image
 		if (_blit)
 		{
 			// get position of the current frame
-			_rect.x = _rect.width * _frame;
-			_rect.y = Std.int(_rect.x / _width) * _rect.height;
-			_rect.x = _rect.x % _width;
-
-			if (_flipped) _rect.x = (_width - _rect.width) - _rect.x;
+			if (_width > 0 && _height > 0) {
+				_rect.x = _rect.width * _frame;
+				_rect.y = Std.int(_rect.x / _width) * _rect.height;
+				_rect.x = _rect.x % _width;
+				if (_flipped) _rect.x = (_width - _rect.width) - _rect.x;
+			}
 
 			// update the buffer
 			super.updateBuffer(clearBefore);


### PR DESCRIPTION
Issue reported and discussed here: http://forum.haxepunk.com/index.php?topic=291.0

I was able to compile for linux64 after applying this fix, and Spritemaps seem to work correctly.
