### PR TITLE
Layers can be negative on all targets (getting rid of HXP.BASELAYER)

### DIFF
--- a/com/haxepunk/Entity.hx
+++ b/com/haxepunk/Entity.hx
@@ -129,7 +129,7 @@ class Entity extends Tweener
 		_point = HXP.point;
 		_camera = HXP.point2;
 
-		layer = HXP.BASELAYER;
+		layer = 0;
 
 		if (graphic != null) this.graphic = graphic;
 		if (mask != null) this.mask = mask;
@@ -542,12 +542,6 @@ class Entity extends Tweener
 	private function set_layer(value:Int):Int
 	{
 		if (_layer == value) return _layer;
-		#if debug
-		if (value < 0)
-		{
-			trace("Negative layers may not work properly if you aren't using flash");
-		}
-		#end
 		if (_graphic != null)
 		{
 			_graphic.setEntity(this); // reset layer

--- a/com/haxepunk/Graphic.hx
+++ b/com/haxepunk/Graphic.hx
@@ -65,7 +65,7 @@ class Graphic
 		relative = true;
 		_scroll = true;
 		_point = new Point();
-		layer = HXP.BASELAYER;
+		layer = 0;
 	}
 
 	/**
@@ -92,7 +92,7 @@ class Graphic
 	public function setEntity(entity:Entity)
 	{
 		_entity = entity;
-		layer = entity != null ? entity.layer : HXP.BASELAYER;
+		layer = entity != null ? entity.layer : 0;
 	}
 
 	/**

--- a/com/haxepunk/HXP.hx
+++ b/com/haxepunk/HXP.hx
@@ -59,11 +59,6 @@ class HXP
 	public static inline var VERSION_PATCH:Int = 6;
 
 	/**
-	 * The standard layer used since only flash can handle negative indicies in arrays, set your layers to some offset of this
-	 */
-	public static inline var BASELAYER:Int = 10;
-
-	/**
 	 * Flash equivalent: Number.MAX_VALUE
 	 */
 #if flash

--- a/com/haxepunk/Scene.hx
+++ b/com/haxepunk/Scene.hx
@@ -6,6 +6,7 @@ import flash.geom.Point;
 import com.haxepunk.Entity;
 import com.haxepunk.Tweener;
 import flash.geom.Rectangle;
+import haxe.ds.IntMap;
 
 /**
  * Updated by Engine, main game container that holds all currently active Entities.
@@ -34,7 +35,7 @@ class Scene extends Tweener
 		_count = 0;
 
 		_layerList = new Array<Int>();
-		_layerCount = new Array<Int>();
+		_layerCount = new Map<Int, Int>();
 		_sprite = new Sprite();
 
 		_add = new Array<Entity>();
@@ -218,10 +219,10 @@ class Scene extends Tweener
 	 * @param	layer		Layer of the Entity.
 	 * @return	The Entity that was added.
 	 */
-	public function addGraphic(graphic:Graphic, layer:Int = HXP.BASELAYER, x:Float = 0, y:Float = 0):Entity
+	public function addGraphic(graphic:Graphic, layer:Int = 0, x:Float = 0, y:Float = 0):Entity
 	{
 		var e:Entity = new Entity(x, y, graphic);
-		if (layer != HXP.BASELAYER) e.layer = layer;
+		e.layer = layer;
 		e.active = false;
 		return add(e);
 	}
@@ -1164,7 +1165,7 @@ class Scene extends Tweener
 			// Append entity to existing layer.
 			fe._renderNext = f;
 			f._renderPrev = e;
-			_layerCount[fe._layer] ++;
+			_layerCount[fe._layer] = _layerCount[fe._layer] + 1;
 		}
 		else
 		{
@@ -1202,7 +1203,15 @@ class Scene extends Tweener
 			}
 		}
 		if (e.graphic != null) e.graphic.destroy();
-		_layerCount[fe._layer] --;
+		var newLayerCount:Int = _layerCount[fe._layer] - 1;
+		if (newLayerCount > 0) {
+			_layerCount[fe._layer] = newLayerCount;
+		} else {
+			// Remove layer from maps if it contains 0 entities.
+			_layerCount.remove(fe._layer);
+			_renderFirst.remove(fe._layer);
+			_renderLast.remove(fe._layer);
+		}
 		fe._renderNext = fe._renderPrev = null;
 	}
 
@@ -1317,7 +1326,7 @@ class Scene extends Tweener
 	private var _sprite:Sprite;
 	private var _layerSort:Bool;
 	private var _layerList:Array<Int>;
-	private var _layerCount:Array<Int>;
+	private var _layerCount:Map<Int, Int>;
 	private var _renderFirst:Map<Int,FriendEntity>;
 	private var _renderLast:Map<Int,FriendEntity>;
 

--- a/com/haxepunk/graphics/Text.hx
+++ b/com/haxepunk/graphics/Text.hx
@@ -188,7 +188,7 @@ class Text extends Image
 	private override function set_layer(value:Int):Int
 	{
 #if neko
-		if (value == null) value = HXP.BASELAYER;
+		if (value == null) value = 0;
 #end
 		if (value == layer) return value;
 		if (_blit == false)


### PR DESCRIPTION
Changed `_layerCount` to be an `IntMap` so now we can have negative layers on neko too. Should also be slightly more performant since Arrays are dense, meaning if you had used layers 10 and 90 you would have had an Array of (90-10) elements with nulls in between.

Tested this with https://github.com/azrafe7/HaxePunk-minitests but if you can try it further would be nice.

Layer value is not showing in the WATCH_LIST, probably this should only be getProperty for all targets here (https://github.com/HaxePunk/HaxePunk/blob/master/com/haxepunk/debug/Console.hx#L961-L965)

And since I'm here, what about a dev branch we can all work on?
