### PR TITLE
Fixing Emitter frame index bug on hardware rendering mode.

### DIFF
--- a/com/haxepunk/graphics/Emitter.hx
+++ b/com/haxepunk/graphics/Emitter.hx
@@ -77,7 +77,7 @@ class Emitter extends Graphic
 			{
 				_frames.push(region.clip(rect, center));
 				rect.x += _frameWidth;
-				if (rect.x > _width)
+				if (rect.x >= _width)
 				{
 					rect.y += _frameHeight;
 					rect.x = 0;


### PR DESCRIPTION
When you reach the edge of the texture, you should immediately move down to the next row, not wait until you're past the edge. This was causing emitter bugs on hardware rendering mode which are now fixed.
