### PR TITLE
Using BitmapData text on hardware render mode

### DIFF
--- a/com/haxepunk/graphics/Text.hx
+++ b/com/haxepunk/graphics/Text.hx
@@ -150,9 +150,15 @@ class Text extends Image
 
 		_source.draw(_field);
 		super.updateBuffer(clearBefore);
-		
+
 		if (_textHardware)
+		{
+			if (_region != null)
+			{
+				_region.destroy();
+			}
 			_region = Atlas.loadImageAsRegion(_source);
+		}
 	}
 
 	/**

--- a/com/haxepunk/graphics/atlas/AtlasData.hx
+++ b/com/haxepunk/graphics/atlas/AtlasData.hx
@@ -115,8 +115,11 @@ class AtlasData
 		_refCount -= 1;
 		if (_refCount <= 0)
 		{
-			HXP.removeBitmap(this._name);
-			_dataPool.remove(this._name);
+			if (this._name != null)
+			{
+				HXP.removeBitmap(this._name);
+				_dataPool.remove(this._name);
+			}
 			_atlases.remove(this);
 		}
 	}

--- a/com/haxepunk/graphics/atlas/AtlasRegion.hx
+++ b/com/haxepunk/graphics/atlas/AtlasRegion.hx
@@ -114,9 +114,18 @@ class AtlasRegion
 		}
 	}
 
+	public function destroy():Void
+	{
+		if (parent != null)
+		{
+			parent.destroy();
+			parent = null;
+		}
+	}
+
 	/**
 	 * Prints the region as a string
-	 * 
+	 *
 	 * @return	String version of the object.
 	 */
 	public function toString():String


### PR DESCRIPTION
Like we said on https://github.com/HaxePunk/HaxePunk/pull/183 I replaced Text to use BitmapData on hardware.

Now it's possible to rotate it and scale it (including screen scale).

The only thing different on hardware is that by default it seems smoothed, but in flash it's not.

I'll look to see if this fix the open text issues.
