### PR TITLE
Should not destroy graphic when entity is removed

### DIFF
--- a/com/haxepunk/Entity.hx
+++ b/com/haxepunk/Entity.hx
@@ -602,10 +602,6 @@ class Entity extends Tweener
 	private function set_graphic(value:Graphic):Graphic
 	{
 		if (_graphic == value) return value;
-		if (_graphic != null)
-		{
-			_graphic.destroy();
-		}
 		_graphic = value;
 		return _graphic;
 	}

--- a/com/haxepunk/Scene.hx
+++ b/com/haxepunk/Scene.hx
@@ -1219,7 +1219,6 @@ class Scene extends Tweener
 				_layerList.pop();
 			}
 		}
-		if (e.graphic != null) e.graphic.destroy();
 		var newLayerCount:Int = _layerCount[fe._layer] - 1;
 		if (newLayerCount > 0) {
 			_layerCount[fe._layer] = newLayerCount;


### PR DESCRIPTION
Should not destroy graphic when entity is removed because graphic object maybe shared.
