### PR TITLE
Fix undocumented side-effect in AtlasRegion.clip

### DIFF
--- a/com/haxepunk/graphics/atlas/AtlasRegion.hx
+++ b/com/haxepunk/graphics/atlas/AtlasRegion.hx
@@ -46,20 +46,23 @@ class AtlasRegion
 	 */
 	public function clip(clipRect:Rectangle, ?center:Point):AtlasRegion
 	{
+		// make a copy of clipRect, to avoid modifying the original
+		var clipRectCopy = new Rectangle( clipRect.x, clipRect.y, clipRect.width, clipRect.height );
+
 		// only clip within the current region
-		if (clipRect.x + clipRect.width > rect.width)
-			clipRect.width = rect.width - clipRect.x;
-		if (clipRect.y + clipRect.height > rect.height)
-			clipRect.height = rect.height - clipRect.y;
+		if (clipRectCopy.x + clipRectCopy.width > rect.width)
+			clipRectCopy.width = rect.width - clipRectCopy.x;
+		if (clipRectCopy.y + clipRectCopy.height > rect.height)
+			clipRectCopy.height = rect.height - clipRectCopy.y;
 
 		// do not allow negative width/height
-		if (clipRect.width < 0) clipRect.width = 0;
-		if (clipRect.height < 0) clipRect.height = 0;
+		if (clipRectCopy.width < 0) clipRectCopy.width = 0;
+		if (clipRectCopy.height < 0) clipRectCopy.height = 0;
 
 		// position clip rect where the last image was
-		clipRect.x += rect.x;
-		clipRect.y += rect.y;
-		return parent.createRegion(clipRect, center);
+		clipRectCopy.x += rect.x;
+		clipRectCopy.y += rect.y;
+		return parent.createRegion(clipRectCopy, center);
 	}
 
 	/**


### PR DESCRIPTION
AtlasRegion.clip shouldn't change the Rectangle
clipRect that is passed as a parameter (at least,
this isn't mentioned in the documentation).

This change makes a local copy of the rectangle,
avoiding the unintended side effect.

The side effect causes a bug when this function
is called in Emitter.setSource while setting up
the AtlasRegions for the different frames of an
animated particle particle effect in hardware
rendering mode. This change should resolve the
problem.
