### PR TITLE
Fixing console bug on Flash

### DIFF
--- a/com/haxepunk/debug/LayerList.hx
+++ b/com/haxepunk/debug/LayerList.hx
@@ -36,7 +36,6 @@ class VisibleLabel extends Sprite
 #end
 
 		this.x = 6;
-		this.display = true;
 
 		addChild(active);
 		addChild(label);
@@ -44,7 +43,7 @@ class VisibleLabel extends Sprite
 		addEventListener("click", onClick, true);
 	}
 
-	public var display(default, set):Bool;
+	public var display(default, set):Bool = true;
 	private function set_display(value:Bool):Bool
 	{
 		if (value != display)


### PR DESCRIPTION
When the console is initialized, set_display is called, which tries to `removeChild(inactive)` and since inactive is not a child of the console yet this raises an exception.

Setting the default value of display to true will prevent it being called during initialization, avoiding this bug.
