### PR TITLE
Use optimized version of drawTiles to avoid shrinking draw array.

### DIFF
--- a/com/haxepunk/graphics/atlas/AtlasData.hx
+++ b/com/haxepunk/graphics/atlas/AtlasData.hx
@@ -154,12 +154,8 @@ class AtlasData
 	{
 		if (_dataIndex != 0)
 		{
-			if (_dataIndex < _data.length)
-			{
-				_data.splice(_dataIndex, _data.length - _dataIndex);
-			}
+			_tilesheet.drawTiles(_scene.sprite.graphics, _data, Atlas.smooth, _renderFlags, _dataIndex);
 			_dataIndex = 0;
-			_tilesheet.drawTiles(_scene.sprite.graphics, _data, Atlas.smooth, _renderFlags);
 		}
 	}
 


### PR DESCRIPTION
This will avoid having to resize the _data array every frame, resulting in fewer memory spikes and faster rendering (sometimes.)

This will require updating to the latest version of lime, openfl, and openfl-native, and for now you'll have to rebuild lime yourself to use it, so it might be best to put off merging this change for now - what does everyone think?
