### PR TITLE
Crosstarget Pixel/Imagemask initial impl (see #215)

### DIFF
--- a/com/haxepunk/Mask.hx
+++ b/com/haxepunk/Mask.hx
@@ -4,8 +4,11 @@ import com.haxepunk.Entity;
 import com.haxepunk.math.Projection;
 import com.haxepunk.math.Vector;
 import com.haxepunk.masks.Masklist;
+import flash.display.BitmapData;
 import flash.display.Graphics;
 import flash.geom.Point;
+import flash.geom.Rectangle;
+import flash.utils.ByteArray;
 
 typedef MaskCallback = Dynamic -> Bool;
 
@@ -125,6 +128,135 @@ class Mask
 		projection.max = max;
 	}
 
+	/**
+	 * Replacement for BitmapData.hitTest() that is not yet available in non-flash targets. TODO: Thorough testing and optimizations.
+	 * 
+	 * @param	firstObject				The first BitmapData object to check against.
+	 * @param	firstPoint				A position of the upper-left corner of the BitmapData image in an arbitrary coordinate space. The same coordinate space is used in defining the secondBitmapPoint parameter.
+	 * @param	firstAlphaThreshold		The smallest alpha channel value that is considered opaque for this hit test.
+	 * @param	secondObject			A Rectangle, Point, Bitmap, or BitmapData object.
+	 * @param	secondPoint				A point that defines a pixel location in the second BitmapData object. Use this parameter only when the value of secondObject is a BitmapData object.
+	 * @param	secondAlphaThreshold	The smallest alpha channel value that is considered opaque in the second BitmapData object. Use this parameter only when the value of secondObject is a BitmapData object and both BitmapData objects are transparent.
+	 * 
+	 * @return  A value of true if a hit occurs; false otherwise.
+	 */
+	public static function hitTest(firstObject:BitmapData, firstPoint:Point, firstAlphaThreshold:Int, secondObject:Dynamic, secondPoint:Point = null, secondAlphaThreshold:Int = 1):Bool 
+	{
+		if (firstPoint == null) {
+			throw "firstPoint cannot be null.";
+		}
+		
+		var rectA:Rectangle = firstObject.rect.clone();
+		var firstBMD:BitmapData = firstObject;
+		var rectB:Rectangle = null;
+		var secondBMD:BitmapData = null;
+		
+		if (Std.is(secondObject, Point)) 
+		{
+			var p:Point = cast secondObject;
+			rectB = new Rectangle(p.x, p.y, 1, 1);
+			var pixel:Int = firstBMD.getPixel32(Std.int(p.x), Std.int(p.y));
+			return (pixel >>> 24) >= firstAlphaThreshold;
+		} 
+		else if (Std.is(secondObject, Rectangle)) 
+		{
+			rectB = (cast secondObject).clone();
+		} 
+		else if (Std.is(secondObject, BitmapData)) 
+		{
+			secondBMD = cast secondObject;
+			rectB = secondBMD.rect.clone();
+		} 
+		else throw "Invalid secondObject. Must be Point, Rectangle or BitmapData.";
+		
+		rectA.x = firstPoint.x;
+		rectA.y = firstPoint.y;
+		if (secondBMD != null && secondPoint != null) 
+		{
+			rectB.x = secondPoint.x;
+			rectB.y = secondPoint.y;
+		} 
+		else 
+		{
+			secondPoint = firstPoint;
+		}
+		
+		var intersectRect:Rectangle = rectA.intersection(rectB);
+		var boundsOverlap:Bool = (intersectRect.width >= 1 && intersectRect.height >= 1);
+		var hit:Bool = false;
+
+		if (boundsOverlap) 
+		{
+			var w:Int = Std.int(intersectRect.width);
+			var h:Int = Std.int(intersectRect.height);
+			
+			// firstObject
+			var xOffset:Float = intersectRect.x > rectA.x ? intersectRect.x - rectA.x : rectA.x - intersectRect.x;
+			var yOffset:Float = intersectRect.y > rectA.y ? intersectRect.y - rectA.y : rectA.y - intersectRect.y;
+			rectA.x += xOffset - firstPoint.x;
+			rectA.y += yOffset - firstPoint.y;
+			rectA.width = w;
+			rectA.height = h;
+
+			// secondObject
+			xOffset = intersectRect.x > rectB.x ? intersectRect.x - rectB.x : rectB.x - intersectRect.x;
+			yOffset = intersectRect.y > rectB.y ? intersectRect.y - rectB.y : rectB.y - intersectRect.y;
+			rectB.x += xOffset - secondPoint.x;
+			rectB.y += yOffset - secondPoint.y;
+			rectB.width = w;
+			rectB.height = h;
+			
+			var pixelsA:ByteArray = firstBMD.getPixels(rectA);
+			var pixelsB:ByteArray = null;
+			if (secondBMD != null) 
+			{
+				pixelsB = secondBMD.getPixels(rectB);
+				pixelsB.position = 0;
+			}
+			pixelsA.position = 0;
+			
+			// analyze overlapping area of BitmapDatas to check for a collision (alpha values >= alpha threshold)
+			var alphaA:Int = 0;
+			var alphaB:Int = 0;
+			var overlapPixels:Int = w * h;
+			var alphaIdx:Int = 0;
+			
+			// check even pixels first
+			for (i in 0...Math.ceil(overlapPixels / 2)) 
+			{
+				alphaIdx = i << 3;
+				alphaA = pixelsA[alphaIdx];
+				alphaB = secondBMD != null ? pixelsB[alphaIdx] : 255;
+				if (alphaA >= firstAlphaThreshold && alphaB >= secondAlphaThreshold) 
+				{
+					hit = true;
+					break; 
+				}
+			}
+			
+			if (!hit) 
+			{
+				// check odd pixels
+				for (i in 0...overlapPixels >> 1) 
+				{
+					alphaIdx = (i << 3) + 4;
+					alphaA = pixelsA[alphaIdx];
+					alphaB = secondBMD != null ? pixelsB[alphaIdx] : 255;
+					if (alphaA >= firstAlphaThreshold && alphaB >= secondAlphaThreshold) 
+					{
+						hit = true;
+						break; 
+					}
+				}
+			}
+			
+			pixelsA = null;
+			pixelsB = null;
+		}
+		
+		return hit;
+	}
+	
 	// Mask information.
 	private var _class:String;
 	private var _check:Map<String,MaskCallback>;

--- a/com/haxepunk/graphics/Image.hx
+++ b/com/haxepunk/graphics/Image.hx
@@ -168,6 +168,25 @@ class Image extends Graphic
 		_bitmap.bitmapData = _buffer;
 	}
 
+	/**
+	 * Force creation and drawing to the buffer even in RenderMode.HARDWARE (needed by Imagemask).
+	 */
+	@:access(com.haxepunk.graphics.atlas.AtlasData)
+	@:access(com.haxepunk.graphics.atlas.AtlasRegion)
+	private function drawBuffer():Void {
+		if (HXP.renderMode == RenderMode.HARDWARE) {
+			if (_bitmap == null) _bitmap = new Bitmap();
+			if (_colorTransform == null) _colorTransform = new ColorTransform();
+			if (_buffer == null) createBuffer();
+		#if flash
+			_source = _region.parent._tilesheet.nmeBitmap;
+		#else
+			_source = _region.parent._tilesheet.__bitmap;
+		#end
+			updateBuffer();
+		}
+	}
+
 	/** Renders the image. */
 	override public function render(target:BitmapData, point:Point, camera:Point)
 	{

--- a/com/haxepunk/masks/Circle.hx
+++ b/com/haxepunk/masks/Circle.hx
@@ -6,13 +6,13 @@ import com.haxepunk.masks.Grid;
 import com.haxepunk.masks.SlopedGrid;
 import com.haxepunk.math.Projection;
 import com.haxepunk.math.Vector;
+import flash.display.BitmapData;
 import flash.display.Graphics;
 import flash.geom.Point;
 
 /**
  * Uses circular area to determine collision.
  */
-
 class Circle extends Hitbox
 {
 	/**
@@ -28,10 +28,15 @@ class Circle extends Hitbox
 		_x = x + radius;
 		_y = y + radius;
 
+		_fakePixelmask = new Pixelmask(new BitmapData(1, 1, true, 0));
+
 		_check.set(Type.getClassName(Mask), collideMask);
 		_check.set(Type.getClassName(Circle), collideCircle);
 		_check.set(Type.getClassName(Hitbox), collideHitbox);
 		_check.set(Type.getClassName(Grid), collideGrid);
+		_check.set(Type.getClassName(Pixelmask), collidePixelmask);
+		_check.set(Type.getClassName(Imagemask), collidePixelmask);
+		_check.set(Type.getClassName(Circle), collideCircle);
 		_check.set(Type.getClassName(SlopedGrid), collideSlopedGrid);
 	}
 
@@ -56,6 +61,7 @@ class Circle extends Hitbox
 		return distanceToCorner <= _squaredRadius;
 	}
 
+	/** @private Collides against a Circle. */
 	private function collideCircle(other:Circle):Bool
 	{
 		var dx:Float = (parent.x + _x) - (other.parent.x + other._x);
@@ -63,6 +69,7 @@ class Circle extends Hitbox
 		return (dx * dx + dy * dy) < Math.pow(_radius + other._radius, 2);
 	}
 
+	/** @private Collides against a Grid. */
 	private function collideGrid(other:Grid):Bool
 	{
 		var thisX:Float = parent.x + _x,
@@ -120,6 +127,50 @@ class Circle extends Hitbox
 		return false;
 	}
 
+	/**
+	 * Checks for collision with a Pixelmask.
+	 * May be slow (especially with big polygons), added for completeness sake.
+	 * 
+	 * Internally sets up a Pixelmask and uses that for collision check.
+	 */
+	@:access(com.haxepunk.masks.Pixelmask)
+	private function collidePixelmask(pixelmask:Pixelmask):Bool
+	{
+		var data:BitmapData = _fakePixelmask._data;
+		
+		_fakePixelmask._x = _x - _radius;
+		_fakePixelmask._y = _y - _radius;
+		_fakePixelmask.parent = parent;
+		
+		_width = _height = _radius * 2;
+		
+		if (data == null || (data.width != _width || data.height != _height)) 
+		{
+			data = new BitmapData(_width, _height, true, 0);
+		} 
+		else 
+		{
+			data.fillRect(data.rect, 0);
+		}
+		
+		var graphics:Graphics = HXP.sprite.graphics;
+		graphics.clear();
+
+		graphics.beginFill(0xFFFFFF, 1);
+		graphics.lineStyle(1, 0xFFFFFF, 1);
+		
+		graphics.drawCircle(_x + parent.originX, _y + parent.originY, _radius);
+		
+		graphics.endFill();
+
+		data.draw(HXP.sprite);
+		
+		_fakePixelmask.data = data;
+
+		return pixelmask.collide(_fakePixelmask);
+	}
+
+	/** @private Collides against a SlopedGrid. */
 	private function collideSlopedGrid(other:SlopedGrid):Bool
 	{
 		var thisX:Float = parent.x + _x,
@@ -262,4 +313,5 @@ class Circle extends Hitbox
 	// Hitbox information.
 	private var _radius:Int;
 	private var _squaredRadius:Int; //Set automatically through the setter for radius
+	private var _fakePixelmask:Pixelmask;	// used for Pixelmask collision
 }

--- a/com/haxepunk/masks/Grid.hx
+++ b/com/haxepunk/masks/Grid.hx
@@ -61,6 +61,7 @@ class Grid extends Hitbox
 		_check.set(Type.getClassName(Mask), collideMask);
 		_check.set(Type.getClassName(Hitbox), collideHitbox);
 		_check.set(Type.getClassName(Pixelmask), collidePixelmask);
+		_check.set(Type.getClassName(Imagemask), collidePixelmask);
 		_check.set(Type.getClassName(Grid), collideGrid);
 
 		data = new Array<Array<Bool>>();
@@ -355,7 +356,6 @@ class Grid extends Hitbox
 	/** @private Collides against a Pixelmask. */
 	private function collidePixelmask(other:Pixelmask):Bool
 	{
-#if flash
 		var x1:Int = Std.int(other.parent.x + other.x - parent.x - _x),
 			y1:Int = Std.int(other.parent.y + other.y - parent.y - _y),
 			x2:Int = Std.int((x1 + other.width - 1) / _tile.width),
@@ -385,7 +385,11 @@ class Grid extends Hitbox
 
 				if (data[y1][x1])
 				{
+#if flash
 					if (other.data.hitTest(_point, 1, _tile)) return true;
+#else
+					if (Mask.hitTest(other.data, _point, 1, _tile)) return true;
+#end
 				}
 				x1 ++;
 				_tile.x += _tile.width;
@@ -395,9 +399,6 @@ class Grid extends Hitbox
 			_tile.x = x1 * _tile.width;
 			_tile.y += _tile.height;
 		}
-#else
-		trace('Pixelmasks will not work in targets other than flash due to hittest not being implemented in OpenFL.');
-#end
 		return false;
 	}
 

--- a/com/haxepunk/masks/Imagemask.hx
+++ b/com/haxepunk/masks/Imagemask.hx
@@ -1,6 +1,7 @@
 package com.haxepunk.masks;
 
 import com.haxepunk.Mask;
+import com.haxepunk.utils.BitmapDataPool;
 import flash.display.BitmapData;
 import flash.geom.Point;
 import flash.geom.Matrix;
@@ -42,6 +43,8 @@ class Imagemask extends Pixelmask
 
 		_bounds = new Rectangle();
 		this.source = source;
+		
+		_check.set(Type.getClassName(Imagemask), collidePixelmask);
 	}
 
 	/** The Image to use as source for the mask. */
@@ -72,7 +75,8 @@ class Imagemask extends Pixelmask
 
 		if (_data == null || (_data.width != _width || _data.height != _height)) 
 		{
-			_data = new BitmapData(_width, _height, true, 0);
+			if (_data != null) BitmapDataPool.recycle(_data);
+			_data = BitmapDataPool.create(_width, _height, true, 0, true);
 		} 
 		else 
 		{

--- a/com/haxepunk/masks/Pixelmask.hx
+++ b/com/haxepunk/masks/Pixelmask.hx
@@ -2,6 +2,9 @@ package com.haxepunk.masks;
 
 import com.haxepunk.Mask;
 import flash.display.BitmapData;
+import flash.display.Graphics;
+import flash.geom.ColorTransform;
+import flash.geom.Matrix;
 import flash.geom.Point;
 import flash.geom.Rectangle;
 import com.haxepunk.HXP;
@@ -27,16 +30,17 @@ class Pixelmask extends Hitbox
 		super();
 
 		// fetch mask data
-		if (Std.is(source, BitmapData))
+		if (Std.is(source, BitmapData)) 
 			_data = source;
-		else
+		else 
 			_data = HXP.getBitmap(source);
-
+		
 		if (_data == null)
 			throw "Invalid Pixelmask source image.";
 
 		threshold = 1;
 
+		_matrix = HXP.matrix;
 		_rect = HXP.rect;
 		_point = HXP.point;
 		_point2 = HXP.point2;
@@ -49,8 +53,8 @@ class Pixelmask extends Hitbox
 
 		// set callback functions
 		_check.set(Type.getClassName(Mask), collideMask);
-		_check.set(Type.getClassName(Pixelmask), collidePixelmask);
 		_check.set(Type.getClassName(Hitbox), collideHitbox);
+		_check.set(Type.getClassName(Pixelmask), collidePixelmask);
 	}
 
 	/** @private Collide against an Entity. */
@@ -62,11 +66,11 @@ class Pixelmask extends Hitbox
 		_rect.y = other.parent.y - other.parent.originY;
 		_rect.width = other.parent.width;
 		_rect.height = other.parent.height;
-		#if flash
+	#if flash
 		return _data.hitTest(_point, threshold, _rect);
-		#else
-		return false;
-		#end
+	#else
+		return Mask.hitTest(_data, _point, threshold, _rect);
+	#end
 	}
 
 	/** @private Collide against a Hitbox. */
@@ -78,54 +82,25 @@ class Pixelmask extends Hitbox
 		_rect.y = other.parent.y + other._y;
 		_rect.width = other._width;
 		_rect.height = other._height;
-		#if flash
+	#if flash
 		return _data.hitTest(_point, threshold, _rect);
-		#else
-		return false;
-		#end
+	#else
+		return Mask.hitTest(_data, _point, threshold, _rect);
+	#end
 	}
 
 	/** @private Collide against a Pixelmask. */
 	private function collidePixelmask(other:Pixelmask):Bool
 	{
-		#if flash
-			_point.x = parent.x + _x;
-			_point.y = parent.y + _y;
-			_point2.x = other.parent.x + other._x;
-			_point2.y = other.parent.y + other._y;
-			return _data.hitTest(_point, threshold, other._data, _point2, other.threshold);
-		#else
-
-			_point.x = other.parent.x + other._x - (parent.x + _x);
-			_point.y = other.parent.y + other._y - (parent.y + _y);
-
-			var r1 = new Rectangle(0, 0, _data.width, _data.height);
-			var r2 = new Rectangle(_point.x, _point.y, other._data.width, other._data.height);
-
-			var intersect = r1.intersection(r2);
-
-			if (intersect.isEmpty())
-			{
-				return false;
-			}
-
-			for(dx in Math.floor(intersect.x)...Math.floor(intersect.x + intersect.width + 1))
-			{
-				for(dy in Math.floor(intersect.y)...Math.floor(intersect.y + intersect.height + 1))
-				{
-					var p1 = (_data.getPixel32(dx, dy) >> 24) & 0xFF;
-					var p2 = (other._data.getPixel32(Math.floor(dx - _point.x),
-							Math.floor(dy - _point.y)) >> 24) & 0xFF;
-
-					if (p1 > 0 && p2 > 0)
-					{
-						return true;
-					}
-				}
-			}
-
-			return false;
-		#end
+		_point.x = parent.x + _x;
+		_point.y = parent.y + _y;
+		_point2.x = other.parent.x + other._x;
+		_point2.y = other.parent.y + other._y;
+	#if flash
+		return _data.hitTest(_point, threshold, other._data, _point2, other.threshold);
+	#else
+		return Mask.hitTest(_data, _point, threshold, other._data, _point2, other.threshold);
+	#end
 	}
 
 	/**
@@ -142,11 +117,60 @@ class Pixelmask extends Hitbox
 		return _data;
 	}
 
+	override public function debugDraw(graphics:Graphics, scaleX:Float, scaleY:Float):Void
+	{
+		_rect.x = 0;
+		_rect.y = 0;
+		_rect.width = _data.width;
+		_rect.height = _data.height;
+		
+		if (_debug == null || (_debug.width != _data.width || _debug.height != _data.height)) 
+		{
+			_debug = new BitmapData(data.width, data.height, true, 0);
+		} 
+		else 
+		{
+			_debug.fillRect(_rect, 0x0);
+		}
+		if (_colorTransform == null) 
+		{
+			_colorTransform = new ColorTransform(1, 1, 1, 0, 0, 0, 0, 0x20);
+		}
+		
+	#if flash
+		_debug.threshold(_data, _rect, HXP.zero, ">=", threshold << 24, 0x400000FF, 0xFF000000);
+	#else
+		/* don't apply alpha threshold in the debug view on non-Flash 'cause it's slow (just show the bitmapdata)*/
+		_debug.draw(_data, null, _colorTransform);
+	#end
+	
+		var sx:Float = scaleX;
+		var sy:Float = scaleY;
+		
+		_matrix.a = sx;
+		_matrix.d = sy;
+		_matrix.b = _matrix.c = 0;
+		_matrix.tx = (parent.x - parent.originX - HXP.camera.x) * sx;
+		_matrix.ty = (parent.y - parent.originY - HXP.camera.y) * sy;
+		
+		graphics.lineStyle();
+		graphics.beginBitmapFill(_debug, _matrix);
+		graphics.drawRect(_matrix.tx, _matrix.ty, _data.width * sx, _data.height * sy);
+		graphics.endFill();
+	}
+	
+	
 	// Pixelmask information.
+	private var _threshold:Int = 1;
 	private var _data:BitmapData;
-
+	private var _debug:BitmapData;
+	
 	// Global objects.
+	private var _matrix:Matrix;
 	private var _rect:Rectangle;
 	private var _point:Point;
 	private var _point2:Point;
+	
+	// Debug Draw.
+	private static var _colorTransform:ColorTransform;
 }

--- a/com/haxepunk/utils/BitmapDataPool.hx
+++ b/com/haxepunk/utils/BitmapDataPool.hx
@@ -1,0 +1,177 @@
+package com.haxepunk.utils;
+
+import flash.display.BitmapData;
+import flash.geom.Rectangle;
+
+/**
+ * BitmapData pool class.
+ * 
+ * Notes on implementation:
+ *     create() starts searching for a suitable BitmapData from the start of the pool list
+ *     recycle() adds the BitmapData to the start of the pool list (removing the last one if the pool exceeds maxLength)
+ * 
+ * @author azrafe7
+ */
+@:access(BitmapDataPoolNode)
+class BitmapDataPool
+{
+	/** Total number of requests made to create(). */
+	public static var requests:Float = 0;
+	
+	/** Number of times a suitable BitmapData was found in the pool after a request to create(). */
+	public static var hits:Float = 0;
+	
+	private static var _head:BitmapDataPoolNode = null;
+	private static var _tail:BitmapDataPoolNode = null;
+	
+	private static var _rect:Rectangle = new Rectangle();
+	
+	private static var _length:Int = 0;
+	private static var _maxLength:Int = 16;
+	
+	/** Maximum number of BitmapData to hold in the pool. */
+	public static var maxLength(get, set):Int;
+	
+	static inline function get_maxLength():Int 
+	{
+		return _maxLength;
+	}
+	
+	static function set_maxLength(value:Int):Int 
+	{
+		if (_maxLength != value) 
+		{
+			var node = _tail;
+			while (node != null && _length > value) 
+			{
+				var bmd = node.bmd;
+				bmd.dispose();
+				bmd = null;
+				node = node.prev;
+				_length--;
+			}
+		}
+		return _maxLength = value;
+	}
+	
+	/** Current number of BitmapData present in the pool. */
+	public static var length(get, null):Int;
+	
+	static function get_length():Int 
+	{
+		return _length;
+	}
+	
+	/** 
+	 * Returns a BitmapData with the specified parameters. 
+	 * If a suitable BitmapData cannot be found in the pool a new one will be created.
+	 * If fillColor is specified the returned BitmapData will also be cleared with it.
+	 * 
+	 * @param ?exactSize	If false a BitmapData with size >= [w, h] may be returned.
+	 */
+	public static function create(w:Int, h:Int, transparent:Bool = true, ?fillColor:Int, ?exactSize:Bool = false):BitmapData 
+	{
+		var res:BitmapData = null;
+		
+		// search the pool
+		var node = _head;
+		while (node != null) 
+		{
+			var bmd = node.bmd;
+			if ((bmd.transparent == transparent && bmd.width >= w && bmd.height >= h) && 
+				(!exactSize || (exactSize && bmd.width == w && bmd.height == h)))
+			{
+				res = bmd;
+				
+				// remove it from pool
+				if (node.prev != null) node.prev.next = node.next;
+				if (node.next != null) node.next.prev = node.prev;
+				if (node == _head) _head = node.next;
+				if (node == _tail) _tail = node.prev;
+				node = null;
+				_length--;
+				break;
+			}
+			node = node.next;
+		}
+		
+		requests++;
+		if (res != null) 	// suitable BitmapData found in the pool
+		{
+			hits++;
+			if (fillColor != null) 
+			{
+				_rect.x = 0;
+				_rect.y = 0;
+				_rect.width = w;
+				_rect.height = h;
+				res.fillRect(_rect, fillColor);
+			}
+		} 
+		else 	// not found: create a new one
+		{
+			res = new BitmapData(w, h, transparent, fillColor != null ? fillColor : 0xFFFFFFFF);
+		}
+		
+		return res;
+	}
+	
+	/** Adds (/recycles) bmd to the pool for future use. */
+	public static function recycle(bmd:BitmapData):Void 
+	{
+		if (_length >= maxLength) 
+		{
+			var last = _tail;
+			last.bmd.dispose();
+			if (last.prev != null) 
+			{
+				last.prev.next = null;
+				_tail = last.prev;
+			}
+			last = null;
+			_length--;
+		}
+		
+		var node = new BitmapDataPoolNode(bmd);
+		node.next = _head;
+		if (_head == null) 
+		{
+			_head = _tail = node;
+		} 
+		else 
+		{
+			_head = node;
+			node.next.prev = node;
+		}
+		_length++;
+	}
+	
+	/** Disposes of all the BitmapData in the pool. */
+	public static function clear():Void 
+	{
+		var node = _head;
+		while (node != null) 
+		{
+			var bmd = node.bmd; 
+			bmd.dispose();
+			bmd = null;
+			node = node.next;
+		}
+		_length = 0;
+		_head = _tail = null;
+	}
+}
+
+@:publicFields
+private class BitmapDataPoolNode {
+	var bmd:BitmapData = null;
+	var prev:BitmapDataPoolNode = null;
+	var next:BitmapDataPoolNode = null;
+	
+	function new(bmd:BitmapData = null, prev:BitmapDataPoolNode = null, next:BitmapDataPoolNode = null):Void 
+	{
+		this.bmd = bmd;
+		this.prev = prev;
+		this.next = next;
+	}
+}


### PR DESCRIPTION
- should work with all mask (except SlopedGrid)
- added implementation of BitmapData.hitTest (as it's not yet provided by openFL)

This works as it is but needs some optimizations:
1. one could be making use of some BitmapData pooling for Imagemask (I have one [over here](https://github.com/azrafe7/HaxePunk/blob/feature/pixelmask/com/haxepunk/utils/BitmapDataPool.hx))
2. making the retrieving of source BitmapData more obvious (esp. HARDWARE)
3. optimize if no transformations are applied (angle, colorTranform, etc.)

A test is here: https://github.com/azrafe7/HaxePunk-minitests/tree/master/TestPixelmask-1 ([swf](https://dl.dropboxusercontent.com/u/32864004/dev/FPDemo/TestPixelmask-1.swf) (download it as it doesn't look good if you open it in the browser :O)

About `#2` see specifically how I _hacked_ around it in https://github.com/azrafe7/HaxePunk/blob/pixelmask-1/com/haxepunk/masks/Imagemask.hx#L85-L96 and https://github.com/azrafe7/HaxePunk/blob/pixelmask-1/com/haxepunk/graphics/Image.hx#L171-L188.

NOTE: This should probably not be merged as it is (well it could be worked upon later but...), I'd like to know your opinion about it (an IRC session maybe? that could probably be the faster way to address my doubts andl lead faster to a solution).
