### PR TITLE
Bug fix: allow initializing an Image with a TileAtlas.

### DIFF
--- a/com/haxepunk/graphics/Image.hx
+++ b/com/haxepunk/graphics/Image.hx
@@ -2,6 +2,7 @@ package com.haxepunk.graphics;
 
 import com.haxepunk.graphics.atlas.Atlas;
 import com.haxepunk.graphics.atlas.TextureAtlas;
+import com.haxepunk.graphics.atlas.TileAtlas;
 import com.haxepunk.graphics.atlas.AtlasRegion;
 import com.haxepunk.Graphic;
 import com.haxepunk.HXP;
@@ -83,6 +84,10 @@ class Image extends Graphic
 			else if (Std.is(source, AtlasRegion))
 			{
 				setAtlasRegion(source);
+			}
+			else if (Std.is(source, TileAtlas))
+			{
+				setAtlasRegion(cast(source, TileAtlas).getRegion(0));
 			}
 			else if (HXP.renderMode == RenderMode.HARDWARE)
 			{


### PR DESCRIPTION
Currently, if you use a TileAtlas as the source of an Image (or a Spritemap, where you would more likely want to) on hardware rendering mode, it will try to get an AtlasData called "TileAtlas" and will fail.

This fix explicitly initializes the Image with the first tile from the TileAtlas.
