### PR TITLE
Fixing Scene.clearRecycledAll bug.

### DIFF
--- a/com/haxepunk/Scene.hx
+++ b/com/haxepunk/Scene.hx
@@ -327,7 +327,7 @@ class Scene extends Tweener
 		var e:Entity;
 		for (e in _recycled)
 		{
-			clearRecycled(Type.resolveClass(e._class));
+			clearRecycled(Type.getClass(e));
 		}
 	}
 


### PR DESCRIPTION
I was getting the following error in the current dev branch of HaxePunk:

/home/ben/Dev/my-HaxePunk/com/haxepunk/Scene.hx:330: characters 0-13 : Constraint check failure for clearRecycled.E
/home/ben/Dev/my-HaxePunk/com/haxepunk/Scene.hx:330: characters 0-13 : Could not resolve full type for constraint checks
/home/ben/Dev/my-HaxePunk/com/haxepunk/Scene.hx:330: characters 0-13 : Type was Unknown<0>

This small change fixed the problem.
