### PR TITLE
Added debugDraw for Hitbox (only triggered if they're in a Masklist) + f...

### DIFF
--- a/com/haxepunk/masks/Hitbox.hx
+++ b/com/haxepunk/masks/Hitbox.hx
@@ -1,6 +1,7 @@
 package com.haxepunk.masks;
 
 import com.haxepunk.Mask;
+import flash.display.Graphics;
 import flash.geom.Point;
 import com.haxepunk.masks.Polygon;
 
@@ -144,6 +145,15 @@ class Hitbox extends Mask
 		}
 	}
 
+	override public function debugDraw(graphics:Graphics, scaleX:Float, scaleY:Float):Void
+	{
+		// draw only if the hitbox is part of a Masklist and has a parent
+		if (list != null && parent != null)
+		{
+			graphics.drawRect((parent.x - HXP.camera.x + x) * scaleX, (parent.y - HXP.camera.y + y) * scaleY, width * scaleX, height * scaleY);
+		}
+	}
+	
 	// Hitbox information.
 	private var _width:Int = 0;
 	private var _height:Int = 0;

--- a/com/haxepunk/masks/Masklist.hx
+++ b/com/haxepunk/masks/Masklist.hx
@@ -143,7 +143,10 @@ class Masklist extends Hitbox
 	override public function update()
 	{
 		// find bounds of the contained masks
-		var t:Int = 0, l:Int = 0, r:Int = 0, b:Int = 0, h:Hitbox;
+		var t:Int, l:Int, r:Int, b:Int, h:Hitbox;
+		t = l = HXP.INT_MAX_VALUE;
+		r = b = HXP.INT_MIN_VALUE;
+		
 		for (m in _masks)
 		{
 			if ((h = cast(m, Hitbox)) != null)


### PR DESCRIPTION
...ixed calc of parent Entity Mask hitbox (partially addresses #241)

Now the hitboxes in a masklist will be visible in the console and the bounds of the entity are calculated correctly.

Minitest: https://github.com/azrafe7/HaxePunk-minitests/tree/master/SimpleTestHitboxMasklist
