### PR TITLE
Small fix for circle vs hitbox collision

### DIFF
--- a/com/haxepunk/masks/Circle.hx
+++ b/com/haxepunk/masks/Circle.hx
@@ -245,8 +245,8 @@ class Circle extends Hitbox
 		var ox:Float = other._x, oy:Float = other._y;
 		if (other.parent != null)
 		{
-			ox = other.parent.x - ox;
-			oy = other.parent.y - oy;
+			ox += other.parent.x;
+			oy += other.parent.y;
 		}
 
 		var distanceX:Float = Math.abs(px - ox - _otherHalfWidth),


### PR DESCRIPTION
`other` hitbox offset was wrong.

... And now I get what you mean by "Don't require parent". So similar changes have to be applied to the other collision masks, as they also don't check for parent existence at the moment.
