### PR TITLE
Fix masklist drawing collision

### DIFF
--- a/com/haxepunk/Mask.hx
+++ b/com/haxepunk/Mask.hx
@@ -115,7 +115,7 @@ class Mask
 		if (cur > max)
 			max = cur;
 
-		cur = (-parent.originX + parent.width) * axis.x + (-parent.originY + parent.height)* axis.y;
+		cur = (-parent.originX + parent.width) * axis.x + (-parent.originY + parent.height) * axis.y;
 		if (cur < min)
 			min = cur;
 		if (cur > max)

--- a/com/haxepunk/masks/Circle.hx
+++ b/com/haxepunk/masks/Circle.hx
@@ -245,8 +245,8 @@ class Circle extends Hitbox
 		var ox:Float = other._x, oy:Float = other._y;
 		if (other.parent != null)
 		{
-			ox = other.parent.x - ox;
-			oy = other.parent.y - oy;
+			ox += other.parent.x;
+			oy += other.parent.y;
 		}
 
 		var distanceX:Float = Math.abs(px - ox - _otherHalfWidth),

--- a/com/haxepunk/masks/Hitbox.hx
+++ b/com/haxepunk/masks/Hitbox.hx
@@ -1,6 +1,8 @@
 package com.haxepunk.masks;
 
 import com.haxepunk.Mask;
+import com.haxepunk.math.Projection;
+import com.haxepunk.math.Vector;
 import flash.display.Graphics;
 import flash.geom.Point;
 import com.haxepunk.masks.Polygon;
@@ -148,10 +150,46 @@ class Hitbox extends Mask
 	override public function debugDraw(graphics:Graphics, scaleX:Float, scaleY:Float):Void
 	{
 		// draw only if the hitbox is part of a Masklist and has a parent
-		if (list != null && parent != null)
+		if (list != null && parent != null && list.count > 1)
 		{
 			graphics.drawRect((parent.x - HXP.camera.x + x) * scaleX, (parent.y - HXP.camera.y + y) * scaleY, width * scaleX, height * scaleY);
 		}
+	}
+	
+	override public function project(axis:Vector, projection:Projection):Void
+	{
+		var px = _x;
+		var py = _y;
+		var cur:Float,
+			max:Float = Math.NEGATIVE_INFINITY,
+			min:Float = Math.POSITIVE_INFINITY;
+
+		cur = px * axis.x + py * axis.y;
+		if (cur < min)
+			min = cur;
+		if (cur > max)
+			max = cur;
+
+		cur = (px + _width) * axis.x + py * axis.y;
+		if (cur < min)
+			min = cur;
+		if (cur > max)
+			max = cur;
+
+		cur = px * axis.x + (py + _height) * axis.y;
+		if (cur < min)
+			min = cur;
+		if (cur > max)
+			max = cur;
+
+		cur = (px + _width) * axis.x + (py + _height) * axis.y;
+		if (cur < min)
+			min = cur;
+		if (cur > max)
+			max = cur;
+
+		projection.min = min;
+		projection.max = max;
 	}
 	
 	// Hitbox information.

--- a/com/haxepunk/masks/Masklist.hx
+++ b/com/haxepunk/masks/Masklist.hx
@@ -146,10 +146,23 @@ class Masklist extends Hitbox
 		var t:Int, l:Int, r:Int, b:Int, h:Hitbox;
 		t = l = HXP.INT_MAX_VALUE;
 		r = b = HXP.INT_MIN_VALUE;
+		var h:Hitbox;
+		var p:Polygon;
 		
 		for (m in _masks)
 		{
-			if ((h = cast(m, Hitbox)) != null)
+			if (Std.is(m, Polygon)) 
+			{
+				p = cast m;
+				if (p != null)
+				{
+					if (p.minX < l) l = p.minX;
+					if (p.minY < t) t = p.minY;
+					if (p.maxX > r) r = p.maxX;
+					if (p.maxY > b) b = p.maxY;
+				}
+			} 
+			else if ((h = cast(m, Hitbox)) != null)
 			{
 				if (h.x < l) l = h.x;
 				if (h.y < t) t = h.y;

--- a/com/haxepunk/masks/Polygon.hx
+++ b/com/haxepunk/masks/Polygon.hx
@@ -22,6 +22,12 @@ class Polygon extends Hitbox
 	public var origin:Point;
 
 
+	// Polygon bounding box.
+	public var minX(default, null):Int = 0;
+	public var minY(default, null):Int = 0;
+	public var maxX(default, null):Int = 0;
+	public var maxY(default, null):Int = 0;
+
 	/**
 	 * Constructor.
 	 * @param	points		An array of coordinates that define the polygon (must have at least 3).
@@ -418,6 +424,11 @@ class Polygon extends Hitbox
 		var projY:Int = Math.round(secondProj.min);
 		_height = Math.round(secondProj.max - secondProj.min);
 
+		minX = projX;
+		minY = projY;
+		maxX = Math.round(minX + _width);
+		maxY = Math.round(minY + _height);
+		
 		if (list != null)
 		{
 			// update parent list
@@ -430,7 +441,6 @@ class Polygon extends Hitbox
 			parent.width = _width;
 			parent.height = _height;
 		}
-
 	}
 
 	/**


### PR DESCRIPTION
- Added project() to Hitbox (now handling offsets)
- Added min/max coords to Polygon
- Masklist updated to differentiate between Hitbox and Polygon (to handle bounds correctly)

This builds on top of #252, addressing #241 and #256.

Minitest: https://github.com/azrafe7/HaxePunk-minitests/tree/master/SimpleTestHitboxMasklist

![](https://dl.dropboxusercontent.com/u/32864004/dev/FPDemo/fixed-masklist.png)
