### PR TITLE
Fixed _key[input] having an error

### DIFF
--- a/com/haxepunk/utils/Input.hx
+++ b/com/haxepunk/utils/Input.hx
@@ -182,7 +182,10 @@ class Input
 			}
 			return false;
 		}
-		return input < 0 ? _keyNum > 0 : _key[input];
+		if (Std.is(input, Int)) {
+			return input < 0 ? _keyNum > 0 : _key[cast input];
+		}
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
Since input is of Dynamic type, it can't be used directly for the
Map<Int, Bool> key. Added a check and a cast
