### PR TITLE
Removed overridden setColor() from Text (probably fixes #233 definitivel...

### DIFF
--- a/com/haxepunk/graphics/Text.hx
+++ b/com/haxepunk/graphics/Text.hx
@@ -299,18 +299,6 @@ class Text extends Image
 	}
 
 	/**
-	 * Override the tinting values for atlas
-	 */
-	override private function set_color(value:Int):Int
-	{
-		value &= 0xFFFFFF;
-		if (_color == value) return value;
-		_color = value;
-		if (blit) updateColorTransform();
-		return _color;
-	}
-
-	/**
 	 * Text string.
 	 */
 	public var text(get, set):String;


### PR DESCRIPTION
...y)

The problem was that Text.setColor() behaved differently from Image.setColor() so _red, _green, _blue were never updated correctly.
