### PR TITLE
Fixed Draw.graphic not working for native targets

### DIFF
--- a/com/haxepunk/utils/Draw.hx
+++ b/com/haxepunk/utils/Draw.hx
@@ -447,9 +447,12 @@ class Draw
 			else HXP.point.x = HXP.point.y = 0;
 			HXP.point2.x = HXP.camera.x;
 			HXP.point2.y = HXP.camera.y;
-			if (HXP.renderMode == RenderMode.BUFFER) {
+			if (HXP.renderMode == RenderMode.BUFFER) 
+			{
 				g.render(_target, HXP.point, HXP.point2);	
-			} else {
+			} 
+			else 
+			{
 				g.renderAtlas(layer, HXP.point, HXP.point2);
 			}
 		}


### PR DESCRIPTION
Added if clause to determine whether to use render or renderAtlas. Also
added a "layer" parameter to draw the graphic on a certain layer
