### PR TITLE
Reverting collidePoint behavior to be consistent with previous versions.

### DIFF
--- a/com/haxepunk/Scene.hx
+++ b/com/haxepunk/Scene.hx
@@ -1104,7 +1104,7 @@ class Scene extends Tweener
 			list = new List<Entity>();
 			_types.set(e._type, list);
 		}
-		list.add(e);
+		list.push(e);
 	}
 
 	/** @private Removes Entity from the type list. */


### PR DESCRIPTION
It seems like recent changes have changed Scene.collidePoint. Previously, if there were multiple entities at the same layer, it would return the last one added (I was relying on this behavior in a UI framework I'm working on.) This makes sense because it's how the draw order works - the last added entity will be visually on top of the layer. Currently, the first added entity is returned instead.
