### PR TITLE
Changed default flash background color to 0x00000000 to match native...

### DIFF
--- a/com/haxepunk/Screen.hx
+++ b/com/haxepunk/Screen.hx
@@ -106,7 +106,7 @@ class Screen
 	public function refresh()
 	{
 		// refreshes the screen
-		HXP.buffer.fillRect(HXP.bounds, Lib.current.stage.color);
+		HXP.buffer.fillRect(HXP.bounds, HXP.stage.color);
 	}
 
 	/**
@@ -144,10 +144,10 @@ class Screen
 	 * Refresh color of the screen.
 	 */
 	public var color(get, set):Int;
-	private function get_color():Int { return Lib.current.stage.color; }
+	private function get_color():Int { return HXP.stage.color; }
 	private function set_color(value:Int):Int
 	{
-		Lib.current.stage.color = value;
+		HXP.stage.color = value;
 		
 		return value;
 	}


### PR DESCRIPTION
...background behavior.

So `<window background="0xFF0000" />` or `Lib.current.stage.color` will be used as default background color like on native targets.
