### PR TITLE
Joystick: update XBOX_GAMEPAD for OpenFL 1.4.0

### DIFF
--- a/com/haxepunk/utils/Joystick.hx
+++ b/com/haxepunk/utils/Joystick.hx
@@ -230,27 +230,40 @@ class OUYA_GAMEPAD
 class XBOX_GAMEPAD
 {
 #if mac
-	public static inline var A_BUTTON:Int = 11;
-	public static inline var B_BUTTON:Int = 12;
-	public static inline var X_BUTTON:Int = 13;
-	public static inline var Y_BUTTON:Int = 14;
-	public static inline var LB_BUTTON:Int = 8;
-	public static inline var RB_BUTTON:Int = 9;
-	public static inline var BACK_BUTTON:Int = 5;
-	public static inline var START_BUTTON:Int = 4;
+	/**
+	 * Button IDs
+	 */
+	public static inline var A_BUTTON:Int = 0;
+	public static inline var B_BUTTON:Int = 1;
+	public static inline var X_BUTTON:Int = 2;
+	public static inline var Y_BUTTON:Int = 3;
+	public static inline var LB_BUTTON:Int = 4;
+	public static inline var RB_BUTTON:Int = 5;
+	public static inline var BACK_BUTTON:Int = 9;
+	public static inline var START_BUTTON:Int = 8;
 	public static inline var LEFT_ANALOGUE_BUTTON:Int = 6;
 	public static inline var RIGHT_ANALOGUE_BUTTON:Int = 7;
+	
+	public static inline var XBOX_BUTTON:Int = 10;
+
+	public static inline var DPAD_UP:Int = 11;
+	public static inline var DPAD_DOWN:Int = 12;
+	public static inline var DPAD_LEFT:Int = 13;
+	public static inline var DPAD_RIGHT:Int = 14;
+	
+	/**
+	 * Axis array indicies
+	 */
 	public static inline var LEFT_ANALOGUE_X:Int = 0;
 	public static inline var LEFT_ANALOGUE_Y:Int = 1;
-	public static inline var RIGHT_ANALOGUE_X:Int = 2;
-	public static inline var RIGHT_ANALOGUE_Y:Int = 3;
-	public static inline var DPAD_UP:Int = 0;
-	public static inline var DPAD_DOWN:Int = 1;
-	public static inline var DPAD_LEFT:Int = 2;
-	public static inline var DPAD_RIGHT:Int = 3;
-
-	//public static inline var TRIGGER:Int = 3;
-#else // default windows mapping
+	public static inline var RIGHT_ANALOGUE_X:Int = 3;
+	public static inline var RIGHT_ANALOGUE_Y:Int = 4;
+	public static inline var LEFT_TRIGGER:Int = 2;
+	public static inline var RIGHT_TRIGGER:Int = 5;
+#elseif linux
+	/**
+	 * Button IDs
+	 */
 	public static inline var A_BUTTON:Int = 0;
 	public static inline var B_BUTTON:Int = 1;
 	public static inline var X_BUTTON:Int = 2;
@@ -259,17 +272,56 @@ class XBOX_GAMEPAD
 	public static inline var RB_BUTTON:Int = 5;
 	public static inline var BACK_BUTTON:Int = 6;
 	public static inline var START_BUTTON:Int = 7;
-	public static inline var LEFT_ANALOGUE_BUTTON:Int = 8;
-	public static inline var RIGHT_ANALOGUE_BUTTON:Int = 9;
+	public static inline var LEFT_ANALOGUE_BUTTON:Int = 9;
+	public static inline var RIGHT_ANALOGUE_BUTTON:Int = 10;
+	
+	public static inline var XBOX_BUTTON:Int = 8;
+	
+	public static inline var DPAD_UP:Int = 13;
+	public static inline var DPAD_DOWN:Int = 14;
+	public static inline var DPAD_LEFT:Int = 11;
+	public static inline var DPAD_RIGHT:Int = 12;
+	
+	/**
+	 * Axis array indicies
+	 */
 	public static inline var LEFT_ANALOGUE_X:Int = 0;
 	public static inline var LEFT_ANALOGUE_Y:Int = 1;
-	public static inline var RIGHT_ANALOGUE_X:Int = 4;
-	public static inline var RIGHT_ANALOGUE_Y:Int = 3;
-
+	public static inline var RIGHT_ANALOGUE_X:Int = 3;
+	public static inline var RIGHT_ANALOGUE_Y:Int = 4;
+	public static inline var LEFT_TRIGGER:Int = 2;
+	public static inline var RIGHT_TRIGGER:Int = 5;
+#else // windows
 	/**
-	* Keep in mind that if TRIGGER axis returns value > 0 then LT is being pressed, and if it's < 0 then RT is being pressed
-	*/
-	public static inline var TRIGGER:Int = 2;
+	 * Button IDs
+	 */
+	public static inline var A_BUTTON:Int = 10;
+	public static inline var B_BUTTON:Int = 11;
+	public static inline var X_BUTTON:Int = 12;
+	public static inline var Y_BUTTON:Int = 13;
+	public static inline var LB_BUTTON:Int = 8;
+	public static inline var RB_BUTTON:Int = 9;
+	public static inline var BACK_BUTTON:Int = 5;
+	public static inline var START_BUTTON:Int = 4;
+	public static inline var LEFT_ANALOGUE_BUTTON:Int = 6;
+	public static inline var RIGHT_ANALOGUE_BUTTON:Int = 7;
+	
+	public static inline var XBOX_BUTTON:Int = 14;
+	
+	public static inline var DPAD_UP:Int = 0;
+	public static inline var DPAD_DOWN:Int = 1;
+	public static inline var DPAD_LEFT:Int = 2;
+	public static inline var DPAD_RIGHT:Int = 3;
+	
+	/**
+	 * Axis array indicies
+	 */
+	public static inline var LEFT_ANALOGUE_X:Int = 0;
+	public static inline var LEFT_ANALOGUE_Y:Int = 1;
+	public static inline var RIGHT_ANALOGUE_X:Int = 2;
+	public static inline var RIGHT_ANALOGUE_Y:Int = 3;
+	public static inline var LEFT_TRIGGER:Int = 4;
+	public static inline var RIGHT_TRIGGER:Int = 5;
 #end
 }
 


### PR DESCRIPTION
OpenFL 1.4.0 broke the button IDs for Xbox 360 controllers, likely due to the upgrade to SDL 2.0.1. From the [changelog](https://forums.libsdl.org/viewtopic.php?p=40162):

> Fixed detecting a mixture of XInput and DirectInput controllers 

Notable differences:
- The dpad can no longer be checked via `JoystickEvent.HAT_MOVE`, no checked like any other button (seems inconsistent that the dpad constants don't have the `_BUTTON`? Not sure, were these previously used in conjunction with hat or as buttons?)
- The Xbox button is now detectable - I added `XBOX_BUTTON` for this
- The left and right trigger are now axes

It seems like the values are different on windows, linux and mac, but oh well. There are a few redundancies, but I feel like it's more readable to have a dedicated section for each OS.

Feel free to double-check these, I think they should work with HaxePunk as they do work with HaxeFlixel, and the gamepad API is pretty similar, but better safe than sorry. :)
