### PR TITLE
Embed assets by default on all platforms.

### DIFF
--- a/include.xml
+++ b/include.xml
@@ -2,8 +2,8 @@
 <project>
 	<app preloader="com.haxepunk.Preloader" unless="noHaxepunkPreloader" />
 
-	<assets path="assets/graphics" rename="gfx" include="*.png" />
-	<assets path="assets/font" rename="font" include="*.ttf" />
+	<assets path="assets/graphics" rename="gfx" include="*.png" embed="true" />
+	<assets path="assets/font" rename="font" include="*.ttf" embed="true" />
 
 	<haxelib name="openfl-ouya" if="ouya" version="1.0.2" />
 	<haxelib name="openfl" version="1.3.0" />


### PR DESCRIPTION
My pull request to lime-tools (https://github.com/openfl/lime-tools/pull/60) was merged, which enables automatically embedding assets within the executable on desktop platforms instead of copying them. These embedded assets are still accessible like through openfl.Assets as before. This needs to be enabled in the project.xml file; if the "embed" flag isn't specified on an asset group in project.xml, it will default to whatever was the previous behavior of the platform in question (on Flash it will embed by default, on desktop, mobile, etc. it won't.)

I propose that we embed HaxePunk's assets by default. Otherwise, even if all assets from the game are set to embed=true, there will still be "graphics" and "font" directories with HaxePunk's assets.
