### PR TITLE
Cube: indexBuffer size bug

### DIFF
--- a/haxepunk/graphics/shapes/Cube.hx
+++ b/haxepunk/graphics/shapes/Cube.hx
@@ -10,6 +10,7 @@ class Cube extends Mesh
 		createBuffers(); // create or reuse buffers
 		_vertexBuffer = defaultVertexBuffer;
 		_indexBuffer = defaultIndexBuffer;
+		_indexSize = 36;
 		super();
 	}
 


### PR DESCRIPTION
_indexSize will give null when creating a second cube, as the _indexSize value is only set on createIndexBuffer(), (which would result in serious lags or even crash)
