### PR TITLE
Compensate for openfl text color bug on Android 

### DIFF
--- a/com/haxepunk/graphics/Text.hx
+++ b/com/haxepunk/graphics/Text.hx
@@ -243,7 +243,7 @@ class Text extends Image
 	{
 		if (_richText == null)
 		{
-			_format.color = 0xFFFFFFFF;
+			_format.color = 0xFFFFFF;
 			_field.setTextFormat(_format);
 		}
 		else
@@ -338,7 +338,7 @@ class Text extends Image
 		if (_richText == "") _field.text = _text = "";
 		if (fromPlain && _richText != null)
 		{
-			_format.color = 0xFFFFFFFF;
+			_format.color = 0xFFFFFF;
 			_red = _green = _blue = 1;
 			updateColorTransform();
 		}


### PR DESCRIPTION
When the alpha channel of flash.text.TextFormat.textColor is set (even if it's 0xFFFFFFFF), it renders as black on Android. Using 0xFFFFFF instead works fine. See https://github.com/openfl/openfl/issues/80.
