### PR TITLE
Fixed HXP.next()

### DIFF
--- a/com/haxepunk/HXP.hx
+++ b/com/haxepunk/HXP.hx
@@ -762,7 +762,7 @@ class HXP
 		if (loop)
 			return options[(indexOf(options, current) + 1) % options.length];
 		else
-			return options[Std.int(Math.max(indexOf(options, current) + 1, options.length - 1))];
+			return options[Std.int(Math.min(indexOf(options, current) + 1, options.length - 1))];
 	}
 
 	/**


### PR DESCRIPTION
HXP.next() was using max() for the non-looping branch instead of min()
