### PR TITLE
Fixed typo with x & y coordinates for Hitbox <-> Hitbox collisions.

### DIFF
--- a/com/haxepunk/masks/Hitbox.hx
+++ b/com/haxepunk/masks/Hitbox.hx
@@ -52,7 +52,7 @@ class Hitbox extends Mask
 			py:Float = _y + _parent.y;
 
 		var ox:Float = other._x + other._parent.x, 
-			oy:Float = other._y + other._parent.x;
+			oy:Float = other._y + other._parent.y;
 
 		return px + _width > ox
 			&& py + _height > oy


### PR DESCRIPTION
Just a quick simple fix for the Hitbox collisions
