### PR TITLE
Modified Sfx for loading sounds during runtime.

### DIFF
--- a/com/haxepunk/Sfx.hx
+++ b/com/haxepunk/Sfx.hx
@@ -42,11 +42,25 @@ class Sfx
 		else
 		{
 			var className:String = Type.getClassName(Type.getClass(source));
-			_sound = _sounds.get(className);
-			if (_sound == null)
+			if ( className == "flash.media.Sound" )
 			{
-				_sound = source;
-				_sounds.set(className, source);
+				// used for loading sound runtime (data-driven for test and debug)
+				var __sound:Sound = cast source;
+				_sound = _sounds.get(__sound.url);
+				if ( _sound == null )
+				{
+					_sound = source;
+					_sounds.set(__sound.url, source);
+				}
+			}
+			else
+			{
+				_sound = _sounds.get(className);
+				if (_sound == null)
+				{
+					_sound = source;
+					_sounds.set(className, source);
+				}
 			}
 		}
 


### PR DESCRIPTION
Checks if source class is flash.media.Sound, cast, and use sound.url as key for _sounds Map. Using this since I'm loading Sound via runtime for test and debug. Found that it works the first time, but whenever I need to play another sound, it always plays the first one loaded.
