### PR TITLE
Fix Image.createPolygon() to properly color the created Image.

### DIFF
--- a/com/haxepunk/graphics/Image.hx
+++ b/com/haxepunk/graphics/Image.hx
@@ -341,9 +341,9 @@ class Image extends Graphic
 		graphics.clear();
 
 		if (fill)
-			graphics.beginFill(color, alpha);
+			graphics.beginFill(0xFFFFFF);
 		else
-			graphics.lineStyle(thick, color, alpha, false, LineScaleMode.NORMAL, null, JointStyle.MITER);
+			graphics.lineStyle(thick, 0xFFFFFF, 1, false, LineScaleMode.NORMAL, null, JointStyle.MITER);
 
 
 		graphics.moveTo(points[points.length - 1].x, points[points.length - 1].y);
@@ -376,6 +376,9 @@ class Image extends Graphic
 		image.originY = image.y - polygon.minY;
 		image.angle = originalAngle;
 		polygon.angle = originalAngle;
+
+        image.color = color;
+        image.alpha = alpha;
 
 		return image;
 	}


### PR DESCRIPTION
This change fixes Image.createPolygon() to properly set the color of the returned Image.

Originally, setting the color using Image.createPolygon() and then changing the hue of the color afterwards using the "color" attribute would result in a change in value rather than in hue. Comparing the Image.createPolygon() to Image.createCircle() (which works properly), it looked like they were drawing the image to the BitmapData object in different ways. I simply modified the Image.createPolygon() function to draw the shape the way Image.createCircle() draws the circle.

I also set the alpha property the same way Image.createCircle() does as well, since I expect a similar problem might exist there.

The change appears to work, and I can now change the color of the Image properly. I tested on neko as well as flash targets.
