### PR TITLE
Fixed screen not clearing on HTML5 target

### DIFF
--- a/com/haxepunk/Screen.hx
+++ b/com/haxepunk/Screen.hx
@@ -109,7 +109,7 @@ class Screen
 	public function refresh()
 	{
 		// refreshes the screen
-		HXP.buffer.fillRect(HXP.bounds, HXP.stage.color);
+		HXP.buffer.fillRect(HXP.bounds, 0xFF000000 | HXP.stage.color);
 	}
 
 	/**


### PR DESCRIPTION
Referencing this problem: http://forum.haxepunk.com/index.php?board=4.0

HXP.screen.fillRect for HTML5 uses ARGB, so HXP.stage.color ends up not having the correct alpha values.