### PR TITLE
Draw state rendering

### DIFF
--- a/com/haxepunk/Scene.hx
+++ b/com/haxepunk/Scene.hx
@@ -136,7 +136,7 @@ class Scene extends Tweener
 		}
 
 		if (HXP.renderMode == RenderMode.HARDWARE)
-			AtlasData.active = null; // forces the last active atlas to flush
+			AtlasData.drawScene(this);
 	}
 
 	/**

--- a/com/haxepunk/graphics/Image.hx
+++ b/com/haxepunk/graphics/Image.hx
@@ -190,11 +190,11 @@ class Image extends Graphic
 			sy = scale * scaleY,
 			fsx = HXP.screen.fullScaleX,
 			fsy = HXP.screen.fullScaleY;
-
+			
 		// determine drawing location
 		_point.x = point.x + x - originX - camera.x * scrollX;
 		_point.y = point.y + y - originY - camera.y * scrollY;
-
+		
 		if (angle == 0)
 		{
 			// UGH... recalculation of _point for scaled origins

--- a/com/haxepunk/graphics/atlas/AtlasRegion.hx
+++ b/com/haxepunk/graphics/atlas/AtlasRegion.hx
@@ -140,5 +140,5 @@ class AtlasRegion
 	private var _rect:Rectangle;
 	private var _parent:AtlasData;
 	
-	private static var matrix:Matrix;
+	private static var matrix:Matrix = new Matrix();
 }

--- a/com/haxepunk/graphics/atlas/AtlasRegion.hx
+++ b/com/haxepunk/graphics/atlas/AtlasRegion.hx
@@ -100,10 +100,10 @@ class AtlasRegion
 		layer:Int, red:Float=1, green:Float=1, blue:Float=1, alpha:Float=1, ?smooth:Bool)
 	{
 		if (smooth == null) smooth = Atlas.smooth;
-
+		
 		if (rotated)
 		{
-			var matrix = new Matrix(a, b, c, d, tx, ty);
+			matrix.setTo(a, b, c, d, tx, ty);
 			matrix.rotate(90 * HXP.RAD);
 			_parent.prepareTileMatrix(_rect, layer,
 				matrix.tx, matrix.ty, matrix.a, matrix.b, matrix.c, matrix.d,
@@ -131,7 +131,7 @@ class AtlasRegion
 	 */
 	public function toString():String
 	{
-		return "[AtlasRegion " + _rect + "]";
+		return "[AtlasRegion " + _rect + "; " + rotated + "]";
 	}
 
 	private inline function get_width():Float { return _rect.width; }
@@ -139,4 +139,6 @@ class AtlasRegion
 
 	private var _rect:Rectangle;
 	private var _parent:AtlasData;
+	
+	private static var matrix:Matrix;
 }

--- a/com/haxepunk/graphics/atlas/DrawState.hx
+++ b/com/haxepunk/graphics/atlas/DrawState.hx
@@ -1,0 +1,133 @@
+package com.haxepunk.graphics.atlas;
+import com.haxepunk.Scene;
+import openfl.display.Tilesheet;
+
+class DrawState
+{
+	private static var poolHead:DrawState;
+	private static var poolTail:DrawState;
+	
+	private static var drawHead:DrawState;
+	private static var drawTail:DrawState;
+	
+	private static function getState(tilesheet:Tilesheet, rgb:Bool, alpha:Bool, smooth:Bool, blend:Int):DrawState
+	{
+		var state:DrawState = null;
+		
+		if (poolHead != null)
+		{
+			state = poolHead;
+			poolHead = state.next;
+			
+			if (poolHead == null)
+			{
+				poolTail = null;
+			}
+		}
+		else
+		{
+			state = new DrawState();
+		}
+		
+		state.set(tilesheet, rgb, alpha, smooth, blend);
+		return state;
+	}
+	
+	private static function putState(state:DrawState):Void
+	{
+		if (poolTail != null)
+		{
+			poolTail.next = state;
+			poolTail = state;
+		}
+		else
+		{
+			poolHead = poolTail = state;
+		}
+	}
+	
+	public static function drawStates(scene:Scene):Void
+	{
+		var next:DrawState = drawHead;
+		var state:DrawState;
+		
+		while (next != null)
+		{
+			state = next;
+			next = state.next;
+			state.render(scene);
+			state.reset();
+		}
+		
+		drawHead = null;
+		drawTail = null;
+	}
+	
+	public static function getDrawState(tilesheet:Tilesheet, rgb:Bool, alpha:Bool, smooth:Bool, blend:Int):DrawState
+	{
+		var state:DrawState = null;
+		if (drawTail != null)
+		{
+			if (drawTail.tilesheet == tilesheet && drawTail.rgb == rgb && drawTail.alpha == alpha && drawTail.smooth == smooth && drawTail.blend == blend)
+			{
+				return drawTail;
+			}
+			else
+			{
+				state = getState(tilesheet, rgb, alpha, smooth, blend);
+				drawTail.next = state;
+				drawTail = state;
+			}
+		}
+		else
+		{
+			state = getState(tilesheet, rgb, alpha, smooth, blend);
+			drawTail = drawHead = state;
+		}
+		
+		return state;
+	}
+	
+	public var tilesheet:Tilesheet;
+	public var data:Array<Float>;
+	public var dataIndex:Int = 0;
+	public var alpha:Bool = false;
+	public var rgb:Bool = false;
+	public var smooth:Bool = false;
+	public var blend:Int = 0;
+	
+	public var next:DrawState;
+	
+	public function new() 
+	{
+		data = [];
+	}
+	
+	public inline function reset():Void
+	{
+		dataIndex = 0;
+		tilesheet = null;
+		next = null;
+		
+		DrawState.putState(this);
+	}
+	
+	public inline function set(tilesheet:Tilesheet, rgb:Bool, alpha:Bool, smooth:Bool, blend:Int):Void
+	{
+		this.tilesheet = tilesheet;
+		this.rgb = rgb;
+		this.alpha = alpha;
+		this.smooth = smooth;
+		this.blend = blend;
+	}
+	
+	public inline function render(scene:Scene):Void
+	{
+		var flags:Int = Tilesheet.TILE_TRANS_2x2 | Tilesheet.TILE_RECT | blend;
+		if (rgb) flags |= Tilesheet.TILE_RGB;
+		if (alpha) flags |= Tilesheet.TILE_ALPHA;
+		
+		tilesheet.drawTiles(scene.sprite.graphics, data, smooth, flags, dataIndex);
+		dataIndex = 0;
+	}
+}

--- a/com/haxepunk/graphics/atlas/DrawState.hx
+++ b/com/haxepunk/graphics/atlas/DrawState.hx
@@ -4,8 +4,7 @@ import openfl.display.Tilesheet;
 
 class DrawState
 {
-	private static var poolHead:DrawState;
-	private static var poolTail:DrawState;
+	private static var pool:DrawState;
 	
 	private static var drawHead:DrawState;
 	private static var drawTail:DrawState;
@@ -14,15 +13,11 @@ class DrawState
 	{
 		var state:DrawState = null;
 		
-		if (poolHead != null)
+		if (pool != null)
 		{
-			state = poolHead;
-			poolHead = state.next;
-			
-			if (poolHead == null)
-			{
-				poolTail = null;
-			}
+			state = pool;
+			pool = state.next;
+			state.next = null;
 		}
 		else
 		{
@@ -35,14 +30,14 @@ class DrawState
 	
 	private static function putState(state:DrawState):Void
 	{
-		if (poolTail != null)
+		if (pool != null)
 		{
-			poolTail.next = state;
-			poolTail = state;
+			state.next = pool;
+			pool = state;
 		}
 		else
 		{
-			poolHead = poolTail = state;
+			pool = state;
 		}
 	}
 	
@@ -58,7 +53,7 @@ class DrawState
 			state.render(scene);
 			state.reset();
 		}
-		
+    
 		drawHead = null;
 		drawTail = null;
 	}
@@ -84,7 +79,7 @@ class DrawState
 			state = getState(tilesheet, rgb, alpha, smooth, blend);
 			drawTail = drawHead = state;
 		}
-		
+    
 		return state;
 	}
 	
@@ -108,7 +103,6 @@ class DrawState
 		dataIndex = 0;
 		tilesheet = null;
 		next = null;
-		
 		DrawState.putState(this);
 	}
 	
@@ -127,7 +121,7 @@ class DrawState
 		if (rgb) flags |= Tilesheet.TILE_RGB;
 		if (alpha) flags |= Tilesheet.TILE_ALPHA;
 		
-		tilesheet.drawTiles(scene.sprite.graphics, data, smooth, flags, dataIndex);
+		if (dataIndex > 0)	tilesheet.drawTiles(scene.sprite.graphics, data, smooth, flags, dataIndex); 
 		dataIndex = 0;
 	}
 }


### PR DESCRIPTION
This pull request should fix issues with `Tilesheet` rendering on native targets, which appeared in recent versions of openfl.

You can find this issue then you have several sprites with different graphics, say you have:
image1 with bitmap1 graphic,
image2 with bitmap2 graphic, 
image3 with bitmap1 graphic again.
If you'll try to render them then you'll see that image1 isn't rendering at all (it become invisible).  

My quess that this rendering issue is caused by the change in `Graphics` class, and how it handles various drawing operations now: it stores draw data for all drawing command until actual graphic rendering process. But the HaxePunk rendering logic assumes that `drawTiles()` will cause immediate draw data transfer to gpu (which was the case in previous versions of openfl). So my solution is to store draw data for each `drawTiles()` call in separare `DrawState` objects (with data batching, of course).

I found this openfl behavior on the last weekend, when i tried to transfer HaxePunk rendering way to my custom batcher. 
I know that my solution will make rendering slower, since it means additional iteration over `DrawState` objects and additional method calls, but it solves the problem. So i ask you to consider it and accept it if you'll find it suitable for your great engine (in which i found many solutions for my needs).
