### PR TITLE
HXP.tween doesn't start the tween automatically

### DIFF
--- a/com/haxepunk/HXP.hx
+++ b/com/haxepunk/HXP.hx
@@ -1150,7 +1150,7 @@ class HXP
 		}
 		var tween:MultiVarTween = new MultiVarTween(complete, type);
 		tween.tween(object, values, duration, ease);
-		tweener.addTween(tween);
+		tweener.addTween(tween, true);
 		return tween;
 	}
 


### PR DESCRIPTION
According to documentation:

"static tween (object : Dynamic, values : Dynamic, duration : Float, ?options : Dynamic) : MultiVarTween
Tweens numeric public properties of an Object. Shorthand for creating a MultiVarTween tween, **starting it** and adding it to a Tweener."

But tweener.addTween needs start=true for that to happens:

HaxePunk/com/haxepunk/Tweener.hx

    public function addTween(t:Tween, start:Bool = false):Tween

It is already corrected in HXP.alarm:

    tweener.addTween(alarm, true);

But not corrected in HXP.tween:

    tweener.addTween(tween);

so I believe it needs to chage to this in order to be compatible with the documentation:

    tweener.addTween(tween, true);