### PR TITLE
Add TileShaderRenderer for OpenFL 4 support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,17 +9,17 @@ matrix:
     - haxe: development
 
 env:
-  - TARGET=flash COMMAND=openfl OPENFL_VERSION=3.6.1 LIME_VERSION=2.9.1
-  - TARGET=neko COMMAND=openfl OPENFL_VERSION=3.6.1 LIME_VERSION=2.9.1
-  - TARGET=cpp COMMAND=openfl OPENFL_VERSION=3.6.1 LIME_VERSION=2.9.1
-  - TARGET=html5 COMMAND=openfl OPENFL_VERSION=3.6.1 LIME_VERSION=2.9.1
-  - TARGET=flash COMMAND=openfl OPENFL_VERSION=4.2.0 LIME_VERSION=3.2.1
-  - TARGET=neko COMMAND=openfl OPENFL_VERSION=4.2.0 LIME_VERSION=3.2.1
-  - TARGET=cpp COMMAND=openfl OPENFL_VERSION=4.2.0 LIME_VERSION=3.2.1
-  - TARGET=html5 COMMAND=openfl OPENFL_VERSION=4.2.0 LIME_VERSION=3.2.1
-  - TARGET=flash COMMAND=nme NME_VERSION=5.6.4
-  - TARGET=neko COMMAND=nme NME_VERSION=5.6.4
-  - TARGET=cpp COMMAND=nme NME_VERSION=5.6.4
+  - TARGET=flash COMMAND=openfl OPENFL=3.6.1 LIME=2.9.1
+  - TARGET=neko COMMAND=openfl OPENFL=3.6.1 LIME=2.9.1
+  - TARGET=cpp COMMAND=openfl OPENFL=3.6.1 LIME=2.9.1
+  - TARGET=html5 COMMAND=openfl OPENFL=3.6.1 LIME=2.9.1
+  - TARGET=flash COMMAND=openfl OPENFL=4.2.0 LIME=3.2.1
+  - TARGET=neko COMMAND=openfl OPENFL=4.2.0 LIME=3.2.1
+  - TARGET=cpp COMMAND=openfl OPENFL=4.2.0 LIME=3.2.1
+  - TARGET=html5 COMMAND=openfl OPENFL=4.2.0 LIME=3.2.1
+  - TARGET=flash COMMAND=nme NME=5.6.4 OPENFL=3.6.1 LIME=2.9.1
+  - TARGET=neko COMMAND=nme NME=5.6.4 OPENFL=3.6.1 LIME=2.9.1
+  - TARGET=cpp COMMAND=nme NME=5.6.4 OPENFL=3.6.1 LIME=2.9.1
 
 neko: "2.0.0"
 
@@ -28,9 +28,9 @@ sudo: false
 install:
   - haxelib dev HaxePunk $TRAVIS_BUILD_DIR
   - if [[ $TARGET == "cpp" ]]; then yes | haxelib install hxcpp > log.txt || cat log.txt; fi
-  - if [[ $LIME_VERSION ]]; then yes | haxelib install lime $LIME_VERSION > log.txt || cat log.txt; fi
-  - if [[ $OPENFL_VERSION ]]; then yes | haxelib install openfl $OPENFL_VERSION > log.txt || cat log.txt; fi
-  - if [[ $NME_VERSION ]]; then yes | haxelib install nme $NME_VERSION > log.txt || cat log.txt; fi
+  - if [[ $LIME ]]; then yes | haxelib install lime $LIME > log.txt || cat log.txt; fi
+  - if [[ $OPENFL ]]; then yes | haxelib install openfl $OPENFL > log.txt || cat log.txt; fi
+  - if [[ $NME ]]; then yes | haxelib install nme $NME > log.txt || cat log.txt; fi
   - yes | haxelib install dox > log.txt || cat log.txt
   - haxelib list
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ sudo: false
 
 install:
   - haxelib dev HaxePunk $TRAVIS_BUILD_DIR
-  - if [[ $TARGET == "cpp" ]]; then yes | haxelib install hxcpp > log.txt || cat log.txt; fi
+  - yes | haxelib install hxcpp > log.txt || cat log.txt
   - if [[ $LIME ]]; then yes | haxelib install lime $LIME > log.txt || cat log.txt; fi
   - if [[ $OPENFL ]]; then yes | haxelib install openfl $OPENFL > log.txt || cat log.txt; fi
   - if [[ $NME ]]; then yes | haxelib install nme $NME > log.txt || cat log.txt; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,8 @@ install:
 
 script:
   - export HXCPP_COMPILE_CACHE=~/.hxcpp_cache
-  - make clean tools unit examples docs COMMAND=$COMMAND TARGET=$TARGET
+  - make clean tools unit examples COMMAND=$COMMAND TARGET=$TARGET
+  - if [[ $TARGET == "openfl" ]]; then make docs; fi
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,17 @@ matrix:
     - haxe: development
 
 env:
-  - TARGET=flash COMMAND=openfl
-  - TARGET=neko COMMAND=openfl
-  - TARGET=cpp COMMAND=openfl
-  - TARGET=html5 COMMAND=openfl
-  - TARGET=flash COMMAND=nme
-  - TARGET=neko COMMAND=nme
-  - TARGET=cpp COMMAND=nme
+  - TARGET=flash COMMAND=openfl OPENFL_VERSION=3.6.1 LIME_VERSION=2.9.1
+  - TARGET=neko COMMAND=openfl OPENFL_VERSION=3.6.1 LIME_VERSION=2.9.1
+  - TARGET=cpp COMMAND=openfl OPENFL_VERSION=3.6.1 LIME_VERSION=2.9.1
+  - TARGET=html5 COMMAND=openfl OPENFL_VERSION=3.6.1 LIME_VERSION=2.9.1
+  - TARGET=flash COMMAND=openfl OPENFL_VERSION=4.2.0 LIME_VERSION=3.2.1
+  - TARGET=neko COMMAND=openfl OPENFL_VERSION=4.2.0 LIME_VERSION=3.2.1
+  - TARGET=cpp COMMAND=openfl OPENFL_VERSION=4.2.0 LIME_VERSION=3.2.1
+  - TARGET=html5 COMMAND=openfl OPENFL_VERSION=4.2.0 LIME_VERSION=3.2.1
+  - TARGET=flash COMMAND=nme NME_VERSION=5.6.4
+  - TARGET=neko COMMAND=nme NME_VERSION=5.6.4
+  - TARGET=cpp COMMAND=nme NME_VERSION=5.6.4
 
 neko: "2.0.0"
 
@@ -23,10 +27,10 @@ sudo: false
 
 install:
   - haxelib dev HaxePunk $TRAVIS_BUILD_DIR
-  - yes | haxelib install lime 2.9.1 > log.txt || cat log.txt
-  - yes | haxelib install openfl 3.6.1 > log.txt || cat log.txt
+  - if [[ $LIME_VERSION ]]; then yes | haxelib install lime $LIME_VERSION > log.txt || cat log.txt; fi
+  - if [[ $OPENFL_VERSION ]]; then yes | haxelib install openfl $OPENFL_VERSION > log.txt || cat log.txt; fi
+  - if [[ $NME_VERSION ]]; then yes | haxelib install nme $NME_VERSION > log.txt || cat log.txt; fi
   - yes | haxelib install dox > log.txt || cat log.txt
-  - yes | haxelib install nme > log.txt || cat log.txt
   - haxelib list
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ sudo: false
 
 install:
   - haxelib dev HaxePunk $TRAVIS_BUILD_DIR
+
   - if [[ $LIME_VERSION ]]; then yes | haxelib install lime $LIME_VERSION > log.txt || cat log.txt; fi
   - if [[ $OPENFL_VERSION ]]; then yes | haxelib install openfl $OPENFL_VERSION > log.txt || cat log.txt; fi
   - if [[ $NME_VERSION ]]; then yes | haxelib install nme $NME_VERSION > log.txt || cat log.txt; fi
@@ -34,7 +35,8 @@ install:
   - haxelib list
 
 script:
-  - make clean tools unit-travis examples docs COMMAND=$COMMAND TARGET=$TARGET
+  - export HXCPP_COMPILE_CACHE=~/.hxcpp_cache
+  - make clean tools unit examples docs COMMAND=$COMMAND TARGET=$TARGET
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ sudo: false
 
 install:
   - haxelib dev HaxePunk $TRAVIS_BUILD_DIR
-
+  - if [[ $TARGET == "cpp" ]]; then yes | haxelib install hxcpp > log.txt || cat log.txt; fi
   - if [[ $LIME_VERSION ]]; then yes | haxelib install lime $LIME_VERSION > log.txt || cat log.txt; fi
   - if [[ $OPENFL_VERSION ]]; then yes | haxelib install openfl $OPENFL_VERSION > log.txt || cat log.txt; fi
   - if [[ $NME_VERSION ]]; then yes | haxelib install nme $NME_VERSION > log.txt || cat log.txt; fi

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-LIME_PATH="$(HOME)/haxe/lib/lime"
 COMMAND=openfl
 TARGET=neko
 

--- a/Makefile
+++ b/Makefile
@@ -46,11 +46,6 @@ unit:
 checkstyle:
 	haxelib run checkstyle -c checkstyle.json -s com
 
-unit-travis:
-	# copy ndll to base path
-	@cp $(LIME_PATH)/`cat $(LIME_PATH)/.current | sed -e 's/\./,/g'`/legacy/ndll/Linux64/* .
-	@make unit # run unit tests
-
 examples: tool.n
 	@git submodule update --init
 	@echo "Building examples with" ${TARGET} "using" ${COMMAND}

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ haxelib: haxepunk.zip
 
 unit:
 	@echo "Running unit tests"
-	@cd tests && haxe compile.hxml && neko unit.n
+	@cd tests && haxe compile.hxml -lib ${COMMAND} && neko unit.n
 
 checkstyle:
 	haxelib run checkstyle -c checkstyle.json -s com

--- a/com/haxepunk/Preloader.hx
+++ b/com/haxepunk/Preloader.hx
@@ -6,7 +6,6 @@ import flash.events.Event;
 import flash.geom.Point;
 import flash.geom.Rectangle;
 
-import openfl.display.Tilesheet;
 
 @:bitmap("assets/graphics/preloader/haxepunk.png")
 class HaxePunkLogo extends BitmapData {}

--- a/com/haxepunk/Preloader.hx
+++ b/com/haxepunk/Preloader.hx
@@ -7,7 +7,7 @@ import flash.geom.Point;
 import flash.geom.Rectangle;
 
 
-#if (openfl > "4.0.0")
+#if (openfl >= "4.0.0")
 typedef Preloader = NMEPreloader;
 #else
 import openfl.display.Tilesheet;

--- a/com/haxepunk/Preloader.hx
+++ b/com/haxepunk/Preloader.hx
@@ -6,12 +6,10 @@ import flash.events.Event;
 import flash.geom.Point;
 import flash.geom.Rectangle;
 
-
 #if (openfl >= "4.0.0")
 typedef Preloader = NMEPreloader;
 #else
 import openfl.display.Tilesheet;
-
 
 @:bitmap("assets/graphics/preloader/haxepunk.png")
 class HaxePunkLogo extends BitmapData {}

--- a/com/haxepunk/Preloader.hx
+++ b/com/haxepunk/Preloader.hx
@@ -7,6 +7,12 @@ import flash.geom.Point;
 import flash.geom.Rectangle;
 
 
+#if (openfl > "4.0.0")
+typedef Preloader = NMEPreloader;
+#else
+import openfl.display.Tilesheet;
+
+
 @:bitmap("assets/graphics/preloader/haxepunk.png")
 class HaxePunkLogo extends BitmapData {}
 
@@ -80,3 +86,4 @@ class Preloader extends NMEPreloader
 	private var tiles:Tilesheet;
 	private var tileData:Array<Float>;
 }
+#end

--- a/com/haxepunk/graphics/atlas/AtlasData.hx
+++ b/com/haxepunk/graphics/atlas/AtlasData.hx
@@ -4,7 +4,6 @@ import com.haxepunk.Scene;
 import flash.display.BitmapData;
 import flash.geom.Rectangle;
 import flash.geom.Point;
-import flash.geom.Matrix;
 
 /**
  * Abstract representing either a `String`, a `AtlasData` or a `BitmapData`.
@@ -29,7 +28,6 @@ abstract AtlasDataType(AtlasData)
 		return new AtlasDataType(data);
 	}
 }
-
 
 class AtlasData
 {
@@ -80,7 +78,7 @@ class AtlasData
 			}
 		}
 
-		_renderFlags = Tilesheet.TILE_TRANS_2x2 | Tilesheet.TILE_ALPHA | Tilesheet.TILE_BLEND_NORMAL | Tilesheet.TILE_RGB | Tilesheet.TILE_RECT;
+		_renderFlags = Tilesheet.TILE_TRANS_2X2 | Tilesheet.TILE_ALPHA | Tilesheet.TILE_BLEND_NORMAL | Tilesheet.TILE_RGB | Tilesheet.TILE_RECT;
 
 		width = bd.width;
 		height = bd.height;

--- a/com/haxepunk/graphics/atlas/AtlasData.hx
+++ b/com/haxepunk/graphics/atlas/AtlasData.hx
@@ -6,30 +6,6 @@ import flash.geom.Rectangle;
 import flash.geom.Point;
 import flash.geom.Matrix;
 
-private class Tilesheet
-{
-	public static inline var TILE_SCALE = 0x0001;
-	public static inline var TILE_ROTATION = 0x0002;
-	public static inline var TILE_RGB = 0x0004;
-	public static inline var TILE_ALPHA = 0x0008;
-	public static inline var TILE_TRANS_2x2 = 0x0010;
-	public static inline var TILE_RECT = 0x0020;
-	public static inline var TILE_ORIGIN = 0x0040;
-	public static inline var TILE_TRANS_COLOR = 0x0080;
-
-	public static inline var TILE_BLEND_NORMAL = 0x00000000;
-	public static inline var TILE_BLEND_ADD = 0x00010000;
-	public static inline var TILE_BLEND_MULTIPLY = 0x00020000;
-	public static inline var TILE_BLEND_SCREEN = 0x00040000;
-	public static inline var TILE_BLEND_SUBTRACT = 0x00080000;
-	public static inline var TILE_BLEND_DARKEN = 0x00100000;
-	public static inline var TILE_BLEND_LIGHTEN = 0x00200000;
-	public static inline var TILE_BLEND_OVERLAY = 0x00400000;
-	public static inline var TILE_BLEND_HARDLIGHT = 0x00800000;
-	public static inline var TILE_BLEND_DIFFERENCE = 0x01000000;
-	public static inline var TILE_BLEND_INVERT = 0x02000000;
-}
-
 /**
  * Abstract representing either a `String`, a `AtlasData` or a `BitmapData`.
  * 

--- a/com/haxepunk/graphics/atlas/Renderer.hx
+++ b/com/haxepunk/graphics/atlas/Renderer.hx
@@ -1,6 +1,5 @@
 package com.haxepunk.graphics.atlas;
 
-
 @:dox(hide)
 class HardwareNotSupportedRenderer
 {
@@ -11,8 +10,6 @@ class HardwareNotSupportedRenderer
 		throw "hardware rendering not supported on this platform";
 	}
 }
-
-
 
 #if (openfl >= "4.0.0")
 #if flash

--- a/com/haxepunk/graphics/atlas/Renderer.hx
+++ b/com/haxepunk/graphics/atlas/Renderer.hx
@@ -1,0 +1,8 @@
+package com.haxepunk.graphics.atlas;
+
+
+#if tile_shader
+typedef Renderer = com.haxepunk.graphics.atlas.renderer.TileShaderRenderer;
+#else
+typedef Renderer = com.haxepunk.graphics.atlas.renderer.DrawTilesRenderer;
+#end

--- a/com/haxepunk/graphics/atlas/Renderer.hx
+++ b/com/haxepunk/graphics/atlas/Renderer.hx
@@ -1,7 +1,7 @@
 package com.haxepunk.graphics.atlas;
 
 
-#if tile_shader
+#if (openfl > "4.0.0")
 typedef Renderer = com.haxepunk.graphics.atlas.renderer.TileShaderRenderer;
 #else
 typedef Renderer = com.haxepunk.graphics.atlas.renderer.DrawTilesRenderer;

--- a/com/haxepunk/graphics/atlas/Renderer.hx
+++ b/com/haxepunk/graphics/atlas/Renderer.hx
@@ -14,7 +14,7 @@ class HardwareNotSupportedRenderer
 
 
 
-#if (openfl > "4.0.0")
+#if (openfl >= "4.0.0")
 #if flash
 // shouldn't be used
 typedef Renderer = HardwareNotSupportedRenderer;

--- a/com/haxepunk/graphics/atlas/Renderer.hx
+++ b/com/haxepunk/graphics/atlas/Renderer.hx
@@ -1,8 +1,26 @@
 package com.haxepunk.graphics.atlas;
 
 
+@:dox(hide)
+class HardwareNotSupportedRenderer
+{
+	public function new(data:AtlasData) {}
+
+	public function drawTiles(graphics, tileData, smooth, flags, count):Void
+	{
+		throw "hardware rendering not supported on this platform";
+	}
+}
+
+
+
 #if (openfl > "4.0.0")
+#if flash
+// shouldn't be used
+typedef Renderer = HardwareNotSupportedRenderer;
+#else
 typedef Renderer = com.haxepunk.graphics.atlas.renderer.TileShaderRenderer;
+#end
 #else
 typedef Renderer = com.haxepunk.graphics.atlas.renderer.DrawTilesRenderer;
 #end

--- a/com/haxepunk/graphics/atlas/Tilesheet.hx
+++ b/com/haxepunk/graphics/atlas/Tilesheet.hx
@@ -1,6 +1,5 @@
 package com.haxepunk.graphics.atlas;
 
-
 /**
  * Renderer-specific flags.
  */
@@ -10,7 +9,7 @@ class Tilesheet
 	public static inline var TILE_ROTATION = 0x0002;
 	public static inline var TILE_RGB = 0x0004;
 	public static inline var TILE_ALPHA = 0x0008;
-	public static inline var TILE_TRANS_2x2 = 0x0010;
+	public static inline var TILE_TRANS_2X2 = 0x0010;
 	public static inline var TILE_RECT = 0x0020;
 	public static inline var TILE_ORIGIN = 0x0040;
 	public static inline var TILE_TRANS_COLOR = 0x0080;

--- a/com/haxepunk/graphics/atlas/Tilesheet.hx
+++ b/com/haxepunk/graphics/atlas/Tilesheet.hx
@@ -1,0 +1,31 @@
+package com.haxepunk.graphics.atlas;
+
+
+/**
+ * Renderer-specific flags.
+ */
+class Tilesheet
+{
+	public static inline var TILE_SCALE = 0x0001;
+	public static inline var TILE_ROTATION = 0x0002;
+	public static inline var TILE_RGB = 0x0004;
+	public static inline var TILE_ALPHA = 0x0008;
+	public static inline var TILE_TRANS_2x2 = 0x0010;
+	public static inline var TILE_RECT = 0x0020;
+	public static inline var TILE_ORIGIN = 0x0040;
+	public static inline var TILE_TRANS_COLOR = 0x0080;
+
+#if (openfl > "4.0.0")
+	public static inline var TILE_BLEND_NORMAL:Int = cast openfl.display.BlendMode.ALPHA;
+	public static inline var TILE_BLEND_ADD:Int = cast openfl.display.BlendMode.ADD;
+	public static inline var TILE_BLEND_MULTIPLY:Int = cast openfl.display.BlendMode.MULTIPLY;
+	public static inline var TILE_BLEND_SCREEN:Int = cast openfl.display.BlendMode.SCREEN;
+	public static inline var TILE_BLEND_SUBTRACT:Int = cast openfl.display.BlendMode.SUBTRACT;
+#else
+	public static inline var TILE_BLEND_NORMAL:Int = openfl.display.Tilesheet.TILE_BLEND_NORMAL;
+	public static inline var TILE_BLEND_ADD:Int = openfl.display.Tilesheet.TILE_BLEND_ADD;
+	public static inline var TILE_BLEND_MULTIPLY:Int = openfl.display.Tilesheet.TILE_BLEND_MULTIPLY;
+	public static inline var TILE_BLEND_SCREEN:Int = openfl.display.Tilesheet.TILE_BLEND_SCREEN;
+	public static inline var TILE_BLEND_SUBTRACT:Int = openfl.display.Tilesheet.TILE_BLEND_SUBTRACT;
+#end
+}

--- a/com/haxepunk/graphics/atlas/Tilesheet.hx
+++ b/com/haxepunk/graphics/atlas/Tilesheet.hx
@@ -15,7 +15,7 @@ class Tilesheet
 	public static inline var TILE_ORIGIN = 0x0040;
 	public static inline var TILE_TRANS_COLOR = 0x0080;
 
-#if (openfl > "4.0.0")
+#if (openfl >= "4.0.0")
 	public static inline var TILE_BLEND_NORMAL:Int = cast openfl.display.BlendMode.ALPHA;
 	public static inline var TILE_BLEND_ADD:Int = cast openfl.display.BlendMode.ADD;
 	public static inline var TILE_BLEND_MULTIPLY:Int = cast openfl.display.BlendMode.MULTIPLY;

--- a/com/haxepunk/graphics/atlas/renderer/DrawTilesRenderer.hx
+++ b/com/haxepunk/graphics/atlas/renderer/DrawTilesRenderer.hx
@@ -1,6 +1,6 @@
 package com.haxepunk.graphics.atlas.renderer;
 
-#if !tile_shader
+#if !(openfl > "4.0.0")
 import com.haxepunk.ds.Either;
 import flash.display.BitmapData;
 import flash.display.Graphics;

--- a/com/haxepunk/graphics/atlas/renderer/DrawTilesRenderer.hx
+++ b/com/haxepunk/graphics/atlas/renderer/DrawTilesRenderer.hx
@@ -1,0 +1,29 @@
+package com.haxepunk.graphics.atlas.renderer;
+
+#if !tile_shader
+import com.haxepunk.ds.Either;
+import flash.display.BitmapData;
+import flash.display.Graphics;
+import flash.display.Sprite;
+import flash.geom.Rectangle;
+import flash.geom.Point;
+import flash.geom.Matrix;
+import openfl.display.Tilesheet;
+
+
+@:access(com.haxepunk.graphics.atlas.AtlasData)
+class DrawTilesRenderer
+{
+	public function new(data:AtlasData)
+	{
+		_tilesheet = new Tilesheet(data.bitmapData);
+	}
+
+	public inline function drawTiles(graphics:Graphics, tileData:Array<Float>, smooth:Bool = false, flags:Int = 0, count:Int = -1):Void
+	{
+		_tilesheet.drawTiles(graphics, tileData, smooth, flags, count);
+	}
+
+	var _tilesheet:Tilesheet;
+}
+#end

--- a/com/haxepunk/graphics/atlas/renderer/DrawTilesRenderer.hx
+++ b/com/haxepunk/graphics/atlas/renderer/DrawTilesRenderer.hx
@@ -1,15 +1,8 @@
 package com.haxepunk.graphics.atlas.renderer;
 
 #if !(openfl >= "4.0.0")
-import com.haxepunk.ds.Either;
-import flash.display.BitmapData;
 import flash.display.Graphics;
-import flash.display.Sprite;
-import flash.geom.Rectangle;
-import flash.geom.Point;
-import flash.geom.Matrix;
 import openfl.display.Tilesheet;
-
 
 @:access(com.haxepunk.graphics.atlas.AtlasData)
 class DrawTilesRenderer

--- a/com/haxepunk/graphics/atlas/renderer/DrawTilesRenderer.hx
+++ b/com/haxepunk/graphics/atlas/renderer/DrawTilesRenderer.hx
@@ -1,6 +1,6 @@
 package com.haxepunk.graphics.atlas.renderer;
 
-#if !(openfl > "4.0.0")
+#if !(openfl >= "4.0.0")
 import com.haxepunk.ds.Either;
 import flash.display.BitmapData;
 import flash.display.Graphics;

--- a/com/haxepunk/graphics/atlas/renderer/TileShaderRenderer.hx
+++ b/com/haxepunk/graphics/atlas/renderer/TileShaderRenderer.hx
@@ -1,6 +1,6 @@
 package com.haxepunk.graphics.atlas.renderer;
 
-#if (openfl > "4.0.0")
+#if ((openfl > "4.0.0") && (!flash))
 import lime.graphics.GLRenderContext;
 import lime.utils.Float32Array;
 import lime.utils.UInt32Array;

--- a/com/haxepunk/graphics/atlas/renderer/TileShaderRenderer.hx
+++ b/com/haxepunk/graphics/atlas/renderer/TileShaderRenderer.hx
@@ -1,0 +1,242 @@
+package com.haxepunk.graphics.atlas.renderer;
+
+#if tile_shader
+import lime.graphics.GLRenderContext;
+import lime.utils.Float32Array;
+import lime.utils.UInt32Array;
+import openfl.display.BitmapData;
+import openfl.display.BlendMode;
+import openfl.display.DisplayObject;
+import openfl.display.Graphics;
+import openfl.display.Shader;
+import openfl.geom.Matrix;
+import openfl.geom.Rectangle;
+import openfl.display.Shader;
+import openfl.gl.GL;
+import openfl.gl.GLBuffer;
+#if !display
+import openfl._internal.renderer.RenderSession;
+import openfl._internal.renderer.opengl.GLRenderer;
+#end
+import com.haxepunk.HXP;
+
+
+@:dox(hide)
+private class TileShader extends Shader
+{
+	public function new()
+	{
+		glVertexSource =
+			"attribute vec4 aPosition;
+			attribute vec2 aTexCoord;
+			attribute vec4 aColor;
+			varying vec2 vTexCoord;
+			varying vec4 vColor;
+
+			uniform mat4 uMatrix;
+
+			void main(void) {
+
+				vTexCoord = aTexCoord;
+				vColor = aColor;
+				gl_Position = uMatrix * aPosition;
+
+			}";
+
+		glFragmentSource =
+			"varying vec2 vTexCoord;
+			varying vec4 vColor;
+			uniform sampler2D uImage0;
+			uniform float uAlpha;
+
+			void main(void) {
+				vec4 color = texture2D (uImage0, vTexCoord);
+
+				if (color.a == 0.0) {
+
+					gl_FragColor = vec4 (0.0, 0.0, 0.0, 0.0);
+
+				} else {
+
+					gl_FragColor = vec4 (color.rgb / color.a, color.a * uAlpha)*vColor;
+
+				}
+			}";
+
+		super();
+	}
+}
+
+
+/**
+ * Rendering backend used for compatibility with OpenFL 4.0, which removed
+ * support for drawTiles. Based on work by @Yanrishatum.
+ */
+@:access(openfl.display.Stage)
+@:access(openfl.display.DisplayObject)
+@:access(openfl.display.Graphics)
+@:access(openfl._internal.renderer.RenderSession)
+@:access(openfl._internal.renderer.opengl.GLRenderer)
+class TileShaderRenderer
+{
+	static inline var BUFFER_CHUNK:Int = 32;
+	static inline var INDEX_CHUNK:Int = 6;
+
+	static var shader:TileShader;
+
+	var data:AtlasData;
+
+	var buffer:Float32Array = new Float32Array(BUFFER_CHUNK);
+	var indexes:UInt32Array = new UInt32Array(INDEX_CHUNK);
+	var glBuffer:GLBuffer;
+	var glIndexes:GLBuffer;
+
+	public function new(data:AtlasData)
+	{
+		this.data = data;
+		if (shader == null) shader = new TileShader();
+	}
+
+	public function drawTiles(graphics:Graphics, tileData:Array<Float>, smooth:Bool = false, flags:Int = 0, count:Int = -1):Void
+	{
+		if (count == -1) count = tileData.length;
+
+		if (count > 0)
+		{
+			var renderer:GLRenderer = cast HXP.stage.__renderer;
+			var renderSession = renderer.renderSession;
+			var gl:GLRenderContext = renderSession.gl;
+			var displayObject:DisplayObject = graphics.__owner;
+
+			var blend:Int = -1;
+			var texture:BitmapData = data.bitmapData;
+
+			var tx:Float, ty:Float, rx:Float, ry:Float, rw:Float, rh:Float, a:Float, b:Float, c:Float, d:Float,
+				uvx:Float, uvy:Float, uvx2:Float, uvy2:Float,
+				red:Float, green:Float, blue:Float, alpha:Float;
+
+			// expand arrays if necessary
+			var items = Std.int(count / 14);
+			if (buffer.length < items * BUFFER_CHUNK)
+			{
+				var newBuffer = new Float32Array(Std.int(Math.max(buffer.length * 2, items * BUFFER_CHUNK)));
+				for (i in 0 ... buffer.length) newBuffer[i] = buffer[i];
+				buffer = newBuffer;
+			}
+			if (indexes.length < items * INDEX_CHUNK)
+			{
+				var newIndexes = new UInt32Array(Std.int(Math.max(indexes.length * 2, items * INDEX_CHUNK)));
+				for (i in 0 ... indexes.length) newIndexes[i] = indexes[i];
+				indexes = newIndexes;
+			}
+
+			var n:Int = 0, bufferPos:Int = 0, i:Int = 0, v:Int = 0, matrix:Matrix = HXP.matrix;
+
+			while (n < count)
+			{
+				tx = tileData[n++];
+				ty = tileData[n++];
+				rx = tileData[n++];
+				ry = tileData[n++];
+				rw = tileData[n++];
+				rh = tileData[n++];
+				a = tileData[n++];
+				b = tileData[n++];
+				c = tileData[n++];
+				d = tileData[n++];
+				red = tileData[n++];
+				green = tileData[n++];
+				blue = tileData[n++];
+				alpha = tileData[n++];
+
+				uvx = (rx / texture.width);
+				uvy = (ry / texture.height);
+				uvx2 = ((rx + rw) / texture.width);
+				uvy2 = ((ry + rh) / texture.height);
+
+				matrix.setTo(a, b, c, d, tx, ty);
+
+				inline function transformX(x, y) return Std.int(0.5 + matrix.__transformX(x, y));
+				inline function transformY(x, y) return Std.int(0.5 + matrix.__transformY(x, y));
+
+				var start = bufferPos;
+				buffer[bufferPos++] = transformX(0, 0);
+				buffer[bufferPos++] = transformY(0, 0);
+				buffer[bufferPos++] = uvx;
+				buffer[bufferPos++] = uvy;
+				buffer[bufferPos++] = red;
+				buffer[bufferPos++] = green;
+				buffer[bufferPos++] = blue;
+				buffer[bufferPos++] = alpha;
+				buffer[bufferPos++] = transformX(rw, 0);
+				buffer[bufferPos++] = transformY(rw, 0);
+				buffer[bufferPos++] = uvx2;
+				buffer[bufferPos++] = uvy;
+				buffer[bufferPos++] = red;
+				buffer[bufferPos++] = green;
+				buffer[bufferPos++] = blue;
+				buffer[bufferPos++] = alpha;
+				buffer[bufferPos++] = transformX(0, rh);
+				buffer[bufferPos++] = transformY(0, rh);
+				buffer[bufferPos++] = uvx;
+				buffer[bufferPos++] = uvy2;
+				buffer[bufferPos++] = red;
+				buffer[bufferPos++] = green;
+				buffer[bufferPos++] = blue;
+				buffer[bufferPos++] = alpha;
+				buffer[bufferPos++] = transformX(rw, rh);
+				buffer[bufferPos++] = transformY(rw, rh);
+				buffer[bufferPos++] = uvx2;
+				buffer[bufferPos++] = uvy2;
+				buffer[bufferPos++] = red;
+				buffer[bufferPos++] = green;
+				buffer[bufferPos++] = blue;
+				buffer[bufferPos++] = alpha;
+				indexes[i++] = v;
+				indexes[i++] = v+1;
+				indexes[i++] = v+2;
+				indexes[i++] = v+2;
+				indexes[i++] = v+1;
+				indexes[i++] = v+3;
+				v += 4;
+			}
+
+			renderSession.shaderManager.setShader(shader);
+			gl.uniform1f(shader.data.uAlpha.index, displayObject.__worldAlpha);
+			gl.uniformMatrix4fv(shader.data.uMatrix.index, false, renderer.getMatrix(displayObject.__worldTransform));
+
+			renderSession.blendModeManager.setBlendMode(cast blend);
+
+			gl.bindTexture(gl.TEXTURE_2D, texture.getTexture(gl));
+			if (smooth)
+			{
+				gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+				gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+			}
+			else
+			{
+				gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+				gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+			}
+
+			if (glBuffer == null)
+			{
+				glBuffer = gl.createBuffer();
+				glIndexes = gl.createBuffer();
+			}
+
+			gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, glIndexes);
+			gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, indexes, gl.DYNAMIC_DRAW);
+
+			gl.bindBuffer(gl.ARRAY_BUFFER, glBuffer);
+			gl.bufferData(gl.ARRAY_BUFFER, buffer, gl.DYNAMIC_DRAW);
+
+			gl.vertexAttribPointer(shader.data.aPosition.index, 2, gl.FLOAT, false, 8 * Float32Array.BYTES_PER_ELEMENT, 0);
+			gl.vertexAttribPointer(shader.data.aTexCoord.index, 2, gl.FLOAT, false, 8 * Float32Array.BYTES_PER_ELEMENT, 2 * Float32Array.BYTES_PER_ELEMENT);
+			gl.vertexAttribPointer(shader.data.aColor.index, 4, gl.FLOAT, false, 8 * Float32Array.BYTES_PER_ELEMENT, 4 * Float32Array.BYTES_PER_ELEMENT);
+
+			gl.drawElements(gl.TRIANGLES, items*6, gl.UNSIGNED_INT, 0);
+		}
+	}
+}
+#end

--- a/com/haxepunk/graphics/atlas/renderer/TileShaderRenderer.hx
+++ b/com/haxepunk/graphics/atlas/renderer/TileShaderRenderer.hx
@@ -1,6 +1,6 @@
 package com.haxepunk.graphics.atlas.renderer;
 
-#if ((openfl > "4.0.0") && (!flash))
+#if ((openfl >= "4.0.0") && (!flash))
 import lime.graphics.GLRenderContext;
 import lime.utils.Float32Array;
 import lime.utils.UInt32Array;

--- a/com/haxepunk/graphics/atlas/renderer/TileShaderRenderer.hx
+++ b/com/haxepunk/graphics/atlas/renderer/TileShaderRenderer.hx
@@ -1,6 +1,6 @@
 package com.haxepunk.graphics.atlas.renderer;
 
-#if tile_shader
+#if (openfl > "4.0.0")
 import lime.graphics.GLRenderContext;
 import lime.utils.Float32Array;
 import lime.utils.UInt32Array;
@@ -97,7 +97,7 @@ class TileShaderRenderer
 		if (shader == null) shader = new TileShader();
 	}
 
-	public function drawTiles(graphics:Graphics, tileData:Array<Float>, smooth:Bool = false, flags:Int = 0, count:Int = -1):Void
+	public inline function drawTiles(graphics:Graphics, tileData:Array<Float>, smooth:Bool = false, flags:Int = 0, count:Int = -1):Void
 	{
 		if (count == -1) count = tileData.length;
 
@@ -108,7 +108,7 @@ class TileShaderRenderer
 			var gl:GLRenderContext = renderSession.gl;
 			var displayObject:DisplayObject = graphics.__owner;
 
-			var blend:Int = -1;
+			var blend:Int = data.blend;
 			var texture:BitmapData = data.bitmapData;
 
 			var tx:Float, ty:Float, rx:Float, ry:Float, rw:Float, rh:Float, a:Float, b:Float, c:Float, d:Float,
@@ -156,8 +156,8 @@ class TileShaderRenderer
 
 				matrix.setTo(a, b, c, d, tx, ty);
 
-				inline function transformX(x, y) return Std.int(0.5 + matrix.__transformX(x, y));
-				inline function transformY(x, y) return Std.int(0.5 + matrix.__transformY(x, y));
+				inline function transformX(x, y) return matrix.__transformX(x, y);
+				inline function transformY(x, y) return matrix.__transformY(x, y);
 
 				var start = bufferPos;
 				buffer[bufferPos++] = transformX(0, 0);

--- a/doc/Main.hx
+++ b/doc/Main.hx
@@ -1,1 +1,1 @@
-class Main { function new() {} }
+class Main { public function new() {} }

--- a/haxelib.json
+++ b/haxelib.json
@@ -8,8 +8,8 @@
 	"releasenote": "See CHANGELOG.md",
 	"contributors": ["heardtheword", "_ibilon", "bendmorris"],
 	"dependencies": {
-		"lime": "2.9.1",
-		"openfl": "3.6.1"
+		"lime": "",
+		"openfl": ""
 	},
 	"install": {
 	}

--- a/include.xml
+++ b/include.xml
@@ -6,8 +6,9 @@
 	<assets path="assets/graphics" rename="graphics" include="*.png" embed="true"/>
 	<assets path="assets/font" rename="font" include="*.ttf" embed="true"/>
 
-	<set name="legacy" unless="next"/>
-	<set name="openfl-legacy" unless="next || hybrid"/>
+	<haxedef name="tile_shader" if="openfl > 4.0"/>
+	<set name="legacy" unless="next || hybrid || tile_shader"/>
+	<set name="openfl-legacy" unless="next || hybrid || tile_shader"/>
 	<haxelib name="openfl-ouya" if="ouya"/>
 	<haxelib name="openfl"/>
 </project>

--- a/include.xml
+++ b/include.xml
@@ -6,9 +6,6 @@
 	<assets path="assets/graphics" rename="graphics" include="*.png" embed="true"/>
 	<assets path="assets/font" rename="font" include="*.ttf" embed="true"/>
 
-	<haxedef name="tile_shader" if="openfl > 4.0"/>
-	<set name="legacy" unless="next || hybrid || tile_shader"/>
-	<set name="openfl-legacy" unless="next || hybrid || tile_shader"/>
 	<haxelib name="openfl-ouya" if="ouya"/>
 	<haxelib name="openfl"/>
 </project>

--- a/tests/compile.hxml
+++ b/tests/compile.hxml
@@ -1,8 +1,6 @@
 -main TestMain
 -neko unit.n
 --remap flash:openfl
--lib lime
--lib openfl
 -lib HaxePunk
 -D lime_cffi
 -D native

--- a/tests/compile.hxml
+++ b/tests/compile.hxml
@@ -4,11 +4,8 @@
 -lib lime
 -lib openfl
 -lib HaxePunk
--D lime-legacy
--D openfl-legacy
--D legacy
+-D lime_cffi
 -D native
--D openfl-native
 -D lime-native
 -D linux
 -D desktop


### PR DESCRIPTION
Still needs polish but submitting now so people can try this out. Adds an OpenGL implementation of drawTiles which falls back to drawTiles if it exists (on NME or older OpenFL versions)

To test,

- install the latest OpenFL and Lime
- check out the feature branch on my fork
- ~~for now you need to compile with `-Dtile_shader -DnoHaxepunkPreloader` to use the TileShaderRenderer~~ special flags no longer needed

Please let me know if you notice any discrepancies.

TODO:

- [x] Add the tile_shader automatically when using OpenFL >= 4.0
- [x] Blend mode support
- [x] Fix the preloader (references Tilesheet)
- [x] Tests/builds passing with OpenFL 3, OpenFL 4, NME
- [x] Benchmarking against drawTiles