### PR TITLE
Added custom cursor support

### DIFF
--- a/com/haxepunk/Cursor.hx
+++ b/com/haxepunk/Cursor.hx
@@ -1,0 +1,27 @@
+package com.haxepunk;
+
+import com.haxepunk.Entity;
+import com.haxepunk.graphics.Graphiclist;
+
+class Cursor extends Entity
+{
+	/**
+	 * Constructor.
+	 * @param	graphic		Graphic to assign to the Entity.
+	 * @param	mask		Mask to assign to the Entity.
+	 */
+	public function new(graphic:Graphic = null, mask:Mask = null)
+	{
+		super(0, 0, graphic, mask);
+	}
+
+	/**
+	 * Updates the entitiy coordinates to match the cursor.
+	 */
+	public override function update()
+	{
+		super.update();
+		x = scene.mouseX;
+		y = scene.mouseY;
+	}
+}

--- a/com/haxepunk/Scene.hx
+++ b/com/haxepunk/Scene.hx
@@ -7,6 +7,7 @@ import com.haxepunk.Entity;
 import com.haxepunk.Tweener;
 import flash.geom.Rectangle;
 import haxe.ds.IntMap;
+import com.haxepunk.Cursor;
 
 /**
  * Updated by `Engine`, main game container that holds all currently active Entities.
@@ -87,6 +88,16 @@ class Scene extends Tweener
 			}
 			if (e.graphic != null && e.graphic.active) e.graphic.update();
 		}
+	}
+
+	/**
+	 * Sets a custom cursor, default layer is the highest unless previosly modified.
+	 * @param Cursor object that will be displayed
+	 */
+	public function setCursor(cursor:Cursor)
+	{
+		if (cursor.layer == 0) cursor.layer = -999999999;
+		add(cursor);
 	}
 
 	/**

--- a/com/haxepunk/Screen.hx
+++ b/com/haxepunk/Screen.hx
@@ -375,7 +375,7 @@ class Screen
 	 * @param	magnitude	Number of pixels to shake in any direction.
 	 * @param	duration	Duration of shake effect, in seconds.
 	 */
-	public function shake(magnitude:Int, duration:Float)
+	public function shake(magnitude:Int = 4, duration:Float = 0.5)
 	{
 		if (_shakeTime < duration) _shakeTime = duration;
 		_shakeMagnitude = magnitude;


### PR DESCRIPTION
As a contribution for the next release, I added a custom entity that follows the cursor around.

This can be accessed through the function setCursor inside the Scene class. I thought of making it apply to every scene, however I felt it was a little bit too intrusive, since I would have to modify classes that don't have anything to do with that sort of procedure, such as HXP, for example.

Anyways, the function receives a Cursor object and automatically sets the layer as the highest it can be, so it is rendered above everything. However, as an exception, if the layer is already modified, this will not happen, as it would imply the user wants the mouse to be at a particular layer, and not above everything else.

Feedback is greatly appreciated, specially referring to the "applies everywhere" cursor idea.