### PR TITLE
Added custom cursor support

### DIFF
--- a/com/haxepunk/HXP.hx
+++ b/com/haxepunk/HXP.hx
@@ -21,8 +21,11 @@ import com.haxepunk.Tween;
 import com.haxepunk.debug.Console;
 import com.haxepunk.tweens.misc.Alarm;
 import com.haxepunk.tweens.misc.MultiVarTween;
+import com.haxepunk.utils.Cursor;
 import com.haxepunk.utils.Ease;
 import com.haxepunk.utils.HaxelibInfo;
+
+import openfl.ui.Mouse;
 
 import haxe.CallStack;
 import haxe.EnumFlags;
@@ -181,6 +184,14 @@ class HXP
 	 * Defines the allowed orientations
 	 */
 	public static var orientations:Array<Int> = [];
+
+	public static var cursor(default,set):Cursor;
+	private static inline function set_cursor(cursor:Cursor = null):Cursor
+	{
+		if (cursor == null) Mouse.show();
+		else Mouse.hide();
+		return HXP.cursor = cursor;
+	}
 
 	/**
 	 * Defines how to render the scene

--- a/com/haxepunk/Scene.hx
+++ b/com/haxepunk/Scene.hx
@@ -3,6 +3,7 @@ package com.haxepunk;
 import com.haxepunk.graphics.atlas.AtlasData;
 import flash.display.Sprite;
 import flash.geom.Point;
+import com.haxepunk.utils.Cursor;
 
 /**
  * Updated by `Engine`, main game container that holds all currently active Entities.
@@ -83,6 +84,12 @@ class Scene extends Tweener
 			}
 			if (e.graphic != null && e.graphic.active) e.graphic.update();
 		}
+
+		// updates the cursor
+		if (HXP.cursor != null && HXP.cursor.active)
+		{
+			HXP.cursor.update();
+		}
 	}
 
 	/**
@@ -129,6 +136,12 @@ class Scene extends Tweener
 			{
 				if (e.visible) e.render();
 			}
+		}
+
+		// renders the cursor
+		if (HXP.cursor != null && HXP.cursor.visible)
+		{
+			HXP.cursor.render();
 		}
 
 		if (HXP.renderMode == RenderMode.HARDWARE)
@@ -978,6 +991,11 @@ class Scene extends Tweener
 	public function updateLists(shouldAdd:Bool = true)
 	{
 		var e:Entity;
+
+		if (HXP.cursor != null)
+		{
+			HXP.cursor._scene = this;
+		}
 
 		// remove entities
 		if (_remove.length > 0)

--- a/com/haxepunk/Scene.hx
+++ b/com/haxepunk/Scene.hx
@@ -3,7 +3,6 @@ package com.haxepunk;
 import com.haxepunk.graphics.atlas.AtlasData;
 import flash.display.Sprite;
 import flash.geom.Point;
-import com.haxepunk.utils.Cursor;
 
 /**
  * Updated by `Engine`, main game container that holds all currently active Entities.

--- a/com/haxepunk/utils/Cursor.hx
+++ b/com/haxepunk/utils/Cursor.hx
@@ -7,7 +7,7 @@ class Cursor extends Entity
 	 * @param	graphic		Graphic to assign to the Entity.
 	 * @param	mask		Mask to assign to the Entity.
 	 */
-	public override function new(?graphic:Graphic = null, ?mask:Mask = null)
+	override public function new(?graphic:Graphic, ?mask:Mask)
 	{
 		super(0, 0, graphic, mask);
 	}
@@ -15,7 +15,7 @@ class Cursor extends Entity
 	/**
 	 * Updates the entitiy coordinates to match the cursor.
 	 */
-	public override function update()
+	override public function update()
 	{
 		super.update();
 		x = scene.mouseX;

--- a/com/haxepunk/utils/Cursor.hx
+++ b/com/haxepunk/utils/Cursor.hx
@@ -1,0 +1,40 @@
+package com.haxepunk.utils;
+
+class Cursor extends Entity
+{
+	/**
+	 * Constructor.
+	 * @param	graphic		Graphic to assign to the Entity.
+	 * @param	mask		Mask to assign to the Entity.
+	 */
+	public function new(graphic:Graphic = null, mask:Mask = null)
+	{
+		super(0, 0, graphic, mask);
+	}
+
+	/**
+	 * Updates the entitiy coordinates to match the cursor.
+	 */
+	public override function update()
+	{
+		super.update();
+		x = scene.mouseX;
+		y = scene.mouseY;
+	}
+
+	/**
+	 * Shows the custom cursor
+	 */
+	public function show()
+	{
+		visible = true;
+	}
+
+	/**
+	 * Hides the custom cursor
+	 */
+	public function hide()
+	{
+		visible = false;
+	}
+}

--- a/com/haxepunk/utils/Cursor.hx
+++ b/com/haxepunk/utils/Cursor.hx
@@ -7,7 +7,7 @@ class Cursor extends Entity
 	 * @param	graphic		Graphic to assign to the Entity.
 	 * @param	mask		Mask to assign to the Entity.
 	 */
-	public function new(graphic:Graphic = null, mask:Mask = null)
+	public override function new(?graphic:Graphic = null, ?mask:Mask = null)
 	{
 		super(0, 0, graphic, mask);
 	}

--- a/com/haxepunk/utils/Input.hx
+++ b/com/haxepunk/utils/Input.hx
@@ -8,6 +8,7 @@ import flash.ui.Multitouch;
 import flash.ui.MultitouchInputMode;
 import com.haxepunk.HXP;
 import com.haxepunk.ds.Either;
+import openfl.ui.Mouse;
 
 #if (openfl_legacy && (cpp || neko))
 	import openfl.events.JoystickEvent;
@@ -131,6 +132,22 @@ class Input
 			return _mouseWheelDelta;
 		}
 		return 0;
+	}
+
+	/**
+	 * Shows the native cursor
+	 */
+	public static function showCursor()
+	{
+		Mouse.show();
+	}
+
+	/**
+	 * Hides the native cursor
+	 */
+	public static function hideCursor()
+	{
+		Mouse.hide();
 	}
 
 	/**


### PR DESCRIPTION
As a contribution for the next release, I added a custom entity that follows the cursor around and also hides the original cursor.

This can be accessed through the function setCursor inside the Scene class. I thought of making it apply to every scene, however I felt it was a little bit too intrusive, since I would have to modify classes that don't have anything to do with that sort of procedure, such as HXP, for example.

Anyways, the function receives a Cursor object and automatically sets the layer as the highest it can be, so it is rendered above everything. However, as an exception, if the layer is already modified, this will not happen, as it would imply the user wants the mouse to be at a particular layer, and not above everything else.

Feedback is greatly appreciated, specially referring to the "applies everywhere" cursor idea.