### PR TITLE
Changed updateTextBuffer to public

### DIFF
--- a/com/haxepunk/graphics/Text.hx
+++ b/com/haxepunk/graphics/Text.hx
@@ -256,7 +256,7 @@ class Text extends Image
 	}
 
 	/** @private Updates the drawing buffer. */
-	private function updateTextBuffer()
+	public function updateTextBuffer()
 	{
 		if (_richText == null)
 		{


### PR DESCRIPTION
Updating attributes off of Text doesn't always refresh the graphic.
So this gives people to option to call it manually to refresh text.