### PR TITLE
Removing static main function (openfl provides)

### DIFF
--- a/template/src/{{PROJECT_CLASS}}.hx
+++ b/template/src/{{PROJECT_CLASS}}.hx
@@ -11,6 +11,4 @@ class {{PROJECT_CLASS}} extends Engine
 #end
 		HXP.scene = new MainScene();
 	}
-
-	public static function main new {{PROJECT_CLASS}}();
 }


### PR DESCRIPTION
The static main function isn't needed because it is provided by openfl. It also doesn't compile with Haxe 3.4.2 as it currently is.

EDIT: I think at one point this was required for neko but it doesn't appear to be an issue now.