### PR TITLE
Half Pixel Offset

### DIFF
--- a/haxepunk/graphics/atlas/DrawCommandBatch.hx
+++ b/haxepunk/graphics/atlas/DrawCommandBatch.hx
@@ -118,7 +118,11 @@ class DrawCommandBatch
 		return command;
 	}
 
-	public inline function addRect(texture:BitmapData, smooth:Bool, blend:BlendMode, uvx:Float, uvy:Float, rw:Float, rh:Float, a:Float, b:Float, c:Float, d:Float, tx:Float, ty:Float, red:Float, green:Float, blue:Float, alpha:Float):Void
+	public inline function addRect(texture:BitmapData, smooth:Bool, blend:BlendMode,
+		rx:Float, ry:Float, rw:Float, rh:Float,
+		a:Float, b:Float, c:Float, d:Float,
+		tx:Float, ty:Float,
+		red:Float, green:Float, blue:Float, alpha:Float):Void
 	{
 		var uvx1:Float, uvy1:Float, uvx2:Float, uvy2:Float;
 		if (texture == null)
@@ -129,10 +133,12 @@ class DrawCommandBatch
 		}
 		else
 		{
-			uvx1 = (uvx / texture.width);
-			uvy1 = (uvy / texture.height);
-			uvx2 = ((uvx + rw) / texture.width);
-			uvy2 = ((uvy + rh) / texture.height);
+			// linear filter requires half pixel offset
+			var offset = smooth ? 0.5 : 0;
+			uvx1 = (rx + offset) / texture.width;
+			uvy1 = (ry + offset) / texture.height;
+			uvx2 = (rx + rw - offset) / texture.width;
+			uvy2 = (ry + rh - offset) / texture.height;
 		}
 
 		var matrix = HXP.matrix;

--- a/haxepunk/graphics/atlas/DrawCommandBatch.hx
+++ b/haxepunk/graphics/atlas/DrawCommandBatch.hx
@@ -129,10 +129,10 @@ class DrawCommandBatch
 		}
 		else
 		{
-			uvx1 = ((uvx + 0.5) / texture.width);
-			uvy1 = ((uvy + 0.5) / texture.height);
-			uvx2 = ((uvx + rw + 0.5) / texture.width);
-			uvy2 = ((uvy + rh + 0.5) / texture.height);
+			uvx1 = (uvx / texture.width);
+			uvy1 = (uvy / texture.height);
+			uvx2 = ((uvx + rw) / texture.width);
+			uvy2 = ((uvy + rh) / texture.height);
 		}
 
 		var matrix = HXP.matrix;


### PR DESCRIPTION
I was migrating an old project to HaxePunk 4.0 and noticed that the texture offsets looked weird. There was an extra pixel on the right and bottom of the sprite. Since OpenGL seems to require half pixel offsets (texel weirdness) I assumed that it was because the uvx2 and uvy2 values were adding instead of subtracting. However, when I changed it to subtraction I noticed that a half pixel on all sides were getting chopped when scaled. It seems that OpenGL isn't using half pixel offsets any more or this is being handled farther down in the HaxePunk/OpenFL code.

Here is an example of the before (top) and after.

![example](https://cloud.githubusercontent.com/assets/620357/24807605/7ae6dc4e-1b7e-11e7-85da-875fc658950f.png)

I am testing on an iMac 2011 Using macOS 10.12.4