### PR TITLE
Debug console doesn't need to handle rendering anymore.

### DIFF
--- a/haxepunk/debug/Console.hx
+++ b/haxepunk/debug/Console.hx
@@ -440,9 +440,6 @@ class Console
 		if (!_enabled || !_visible)
 			return;
 
-		if (_paused)
-			HXP.engine.render();
-
 		// move on resize
 		_entRead.x = width - _entReadText.width;
 		_layerList.x = width - _layerList.width - 20;
@@ -608,6 +605,7 @@ class Console
 	function stepFrame()
 	{
 		HXP.engine.update();
+		HXP.engine.render();
 		updateEntityCount();
 		updateEntityLists();
 		renderEntities();


### PR DESCRIPTION
This was necessary at some point but the ENTER_FRAME callback renders the scene regardless of whether the console is shown. Calling it here results in double counting the FPS.

Assigning @MattTuttle if you want to take a look, otherwise kick it back to me.

Fixes #454 