### PR TITLE
Refactoring abstract classes to use haxe.ds.Either

### DIFF
--- a/haxepunk/Entity.hx
+++ b/haxepunk/Entity.hx
@@ -2,24 +2,12 @@ package haxepunk;
 
 import flash.display.BitmapData;
 import flash.geom.Point;
+import haxe.ds.Either;
+import haxepunk.ds.OneOf;
 import haxepunk.graphics.Graphiclist;
-import haxepunk.ds.Either;
 import haxepunk.utils.MathUtil;
 
-
-/**
- * Abstract representing either a `String` or a `Array<String>`.
- *
- * Conversion is automatic, no need to use this.
- */
-abstract SolidType(Either<String, Array<String>>)
-{
-	@:dox(hide) public inline function new( e:Either<String, Array<String>> ) this = e;
-	@:dox(hide) public var type(get, never):Either<String, Array<String>>;
-	@:to inline function get_type() return this;
-	@:from static function fromLeft(v:String) return new SolidType(Left(v));
-	@:from static function fromRight(v:Array<String>) return new SolidType(Right(v));
-}
+typedef SolidType = OneOf<String, Array<String>>;
 
 /**
  * Main game Entity class updated by `Scene`.
@@ -270,9 +258,7 @@ class Entity extends Tweener
 	 */
 	public function collideTypes(types:SolidType, x:Float, y:Float):Entity
 	{
-		if (_scene == null) return null;
-
-		switch (types.type)
+		switch (types)
 		{
 			case Left(s):
 				return collide(s, x, y);

--- a/haxepunk/Graphic.hx
+++ b/haxepunk/Graphic.hx
@@ -1,6 +1,6 @@
 package haxepunk;
 
-import haxepunk.ds.Either;
+import haxe.ds.Either;
 import haxepunk.graphics.atlas.Atlas;
 import haxepunk.graphics.atlas.TileAtlas;
 import haxepunk.graphics.atlas.AtlasRegion;
@@ -12,29 +12,25 @@ import flash.geom.Point;
  *
  * Conversion is automatic, no need to use this.
  */
-abstract TileType(Either<BitmapData, TileAtlas>)
+abstract TileType(Either<BitmapData, TileAtlas>) from Either<BitmapData, TileAtlas>
 {
-	inline function new(e:Either<BitmapData, TileAtlas>) this = e;
-	@:dox(hide) public var type(get, never):Either<BitmapData, TileAtlas>;
-	@:to inline function get_type() return this;
-
-	@:dox(hide) @:from public static inline function fromString(tileset:String)
+	@:dox(hide) @:from public static inline function fromString(tileset:String):TileType
 	{
 		if (HXP.renderMode == RenderMode.HARDWARE)
-			return new TileType(Right(new TileAtlas(tileset)));
+			return Right(new TileAtlas(tileset));
 		else
-			return new TileType(Left(HXP.getBitmap(tileset)));
+			return Left(HXP.getBitmap(tileset));
 	}
-	@:dox(hide) @:from public static inline function fromTileAtlas(atlas:TileAtlas)
+	@:dox(hide) @:from public static inline function fromTileAtlas(atlas:TileAtlas):TileType
 	{
-		return new TileType(Right(atlas));
+		return Right(atlas);
 	}
-	@:dox(hide) @:from public static inline function fromBitmapData(bd:BitmapData)
+	@:dox(hide) @:from public static inline function fromBitmapData(bd:BitmapData):TileType
 	{
 		if (HXP.renderMode == RenderMode.HARDWARE)
-			return new TileType(Right(new TileAtlas(bd)));
+			return Right(new TileAtlas(bd));
 		else
-			return new TileType(Left(bd));
+			return Left(bd);
 	}
 }
 
@@ -43,33 +39,29 @@ abstract TileType(Either<BitmapData, TileAtlas>)
  *
  * Conversion is automatic, no need to use this.
  */
-abstract ImageType(Either<BitmapData, AtlasRegion>)
+abstract ImageType(Either<BitmapData, AtlasRegion>) from Either<BitmapData, AtlasRegion>
 {
-	inline function new(e:Either<BitmapData, AtlasRegion>) this = e;
-	@:dox(hide) public var type(get, never):Either<BitmapData, AtlasRegion>;
-	@:to inline function get_type() return this;
-
-	@:dox(hide) @:from public static inline function fromString(s:String)
+	@:dox(hide) @:from public static inline function fromString(s:String):ImageType
 	{
 		if (HXP.renderMode == RenderMode.HARDWARE)
-			return new ImageType(Right(Atlas.loadImageAsRegion(s)));
+			return Right(Atlas.loadImageAsRegion(s));
 		else
-			return new ImageType(Left(HXP.getBitmap(s)));
+			return Left(HXP.getBitmap(s));
 	}
-	@:dox(hide) @:from public static inline function fromTileAtlas(atlas:TileAtlas)
+	@:dox(hide) @:from public static inline function fromTileAtlas(atlas:TileAtlas):ImageType
 	{
-		return new ImageType(Right(atlas.getRegion(0)));
+		return Right(atlas.getRegion(0));
 	}
-	@:dox(hide) @:from public static inline function fromAtlasRegion(region:AtlasRegion)
+	@:dox(hide) @:from public static inline function fromAtlasRegion(region:AtlasRegion):ImageType
 	{
-		return new ImageType(Right(region));
+		return Right(region);
 	}
-	@:dox(hide) @:from public static inline function fromBitmapData(bd:BitmapData)
+	@:dox(hide) @:from public static inline function fromBitmapData(bd:BitmapData):ImageType
 	{
 		if (HXP.renderMode == RenderMode.HARDWARE)
-			return new ImageType(Right(Atlas.loadImageAsRegion(bd)));
+			return Right(Atlas.loadImageAsRegion(bd));
 		else
-			return new ImageType(Left(bd));
+			return Left(bd);
 	}
 
 	public var width(get, never):Int;
@@ -98,20 +90,20 @@ abstract ImageType(Either<BitmapData, AtlasRegion>)
  *
  * Conversion is automatic, no need to use this.
  */
-abstract ImageOrTileType(Either<ImageType, TileType>)
+@:dox(hide)
+abstract ImageOrTileType(Either<ImageType, TileType>) from Either<ImageType, TileType>
 {
-	inline function new(e:Either<ImageType, TileType>) this = e;
-	@:dox(hide) public var type(get, never):Either<ImageType, TileType>;
-	@:to inline function get_type() return this;
+	@:from public static inline function fromString(tileset:String):ImageOrTileType
+		return Right(TileType.fromString(tileset));
 
-	@:dox(hide) @:from public static inline function fromString(tileset:String):ImageOrTileType
-	return new ImageOrTileType(Right(TileType.fromString(tileset)));
-	@:dox(hide) @:from public static inline function fromBitmapData(bd:BitmapData):ImageOrTileType
-	return new ImageOrTileType(Right(TileType.fromBitmapData(bd)));
-	@:dox(hide) @:from public static inline function fromTileAtlas(atlas:TileAtlas):ImageOrTileType
-	return new ImageOrTileType(Right(TileType.fromTileAtlas(atlas)));
-	@:dox(hide) @:from public static inline function fromAtlasRegion(region:AtlasRegion):ImageOrTileType
-	return new ImageOrTileType(Left(ImageType.fromAtlasRegion(region)));
+	@:from public static inline function fromBitmapData(bd:BitmapData):ImageOrTileType
+		return Right(TileType.fromBitmapData(bd));
+
+	@:from public static inline function fromTileAtlas(atlas:TileAtlas):ImageOrTileType
+		return Right(TileType.fromTileAtlas(atlas));
+
+	@:from public static inline function fromAtlasRegion(region:AtlasRegion):ImageOrTileType
+		return Left(ImageType.fromAtlasRegion(region));
 }
 
 /**

--- a/haxepunk/ds/Either.hx
+++ b/haxepunk/ds/Either.hx
@@ -1,8 +1,0 @@
-package haxepunk.ds;
-
-@:dox(hide)
-enum Either<L, R>
-{
-	Left( v:L );
-	Right( v:R );
-}

--- a/haxepunk/ds/OneOf.hx
+++ b/haxepunk/ds/OneOf.hx
@@ -8,6 +8,21 @@ abstract OneOf<L, R>(Either<L, R>) from Either<L, R> to Either<L, R>
 	@:from public static function fromL<L, R>(val:L):OneOf<L, R> return Left(val);
 	@:from public static function fromR<L, R>(val:R):OneOf<L, R> return Right(val);
 
-	@:to inline function toL():Null<L> return switch(this) {case Left(val): val; default: null;}
-	@:to inline function toR():Null<R> return switch(this) {case Right(val): val; default: null;}
+	@:to inline function toL():Null<L>
+	{
+		return switch (this)
+		{
+			case Left(val): val;
+			default: null;
+		}
+	}
+
+	@:to inline function toR():Null<R>
+	{
+		return switch (this)
+		{
+			case Right(val): val;
+			default: null;
+		}
+	}
 }

--- a/haxepunk/ds/OneOf.hx
+++ b/haxepunk/ds/OneOf.hx
@@ -1,0 +1,13 @@
+package haxepunk.ds;
+
+import haxe.ds.Either;
+
+@:dox(hide)
+abstract OneOf<L, R>(Either<L, R>) from Either<L, R> to Either<L, R>
+{
+	@:from public static function fromL<L, R>(val:L):OneOf<L, R> return Left(val);
+	@:from public static function fromR<L, R>(val:R):OneOf<L, R> return Right(val);
+
+	@:to inline function toL():Null<L> return switch(this) {case Left(val): val; default: null;}
+	@:to inline function toR():Null<R> return switch(this) {case Right(val): val; default: null;}
+}

--- a/haxepunk/graphics/Backdrop.hx
+++ b/haxepunk/graphics/Backdrop.hx
@@ -2,6 +2,7 @@ package haxepunk.graphics;
 
 import flash.display.BitmapData;
 import flash.geom.Point;
+import haxe.ds.Either;
 import haxepunk.graphics.atlas.AtlasRegion;
 import haxepunk.HXP;
 import haxepunk.Graphic;
@@ -21,7 +22,7 @@ class Backdrop extends Canvas
 	 */
 	public function new(source:ImageType, repeatX:Bool = true, repeatY:Bool = true, screenScale:Float = 1.)
 	{
-		switch (source.type)
+		switch (source)
 		{
 			case Left(bitmap):
 				blit = true;

--- a/haxepunk/graphics/Emitter.hx
+++ b/haxepunk/graphics/Emitter.hx
@@ -3,6 +3,7 @@ package haxepunk.graphics;
 import flash.display.BitmapData;
 import flash.display.BlendMode;
 import flash.geom.Point;
+import haxe.ds.Either;
 import haxepunk.HXP;
 import haxepunk.Graphic;
 import haxepunk.graphics.atlas.AtlasRegion;
@@ -49,7 +50,7 @@ class Emitter extends Graphic
 	 */
 	public function setSource(source:ImageOrTileType, frameWidth:Int = 0, frameHeight:Int = 0)
 	{
-		switch (source.type)
+		switch (source)
 		{
 			case Left(img):
 				_source = new Image(img);

--- a/haxepunk/graphics/Image.hx
+++ b/haxepunk/graphics/Image.hx
@@ -10,6 +10,7 @@ import flash.geom.Rectangle;
 import flash.display.Graphics;
 import flash.display.JointStyle;
 import flash.display.LineScaleMode;
+import haxe.ds.Either;
 import haxepunk.Camera;
 import haxepunk.Graphic;
 import haxepunk.HXP;
@@ -90,7 +91,7 @@ class Image extends Graphic
 		// check if the _source or _region were set in a higher class
 		if (source != null)
 		{
-			switch (source.type)
+			switch (source)
 			{
 				case Left(bitmap):
 					blit = true;

--- a/haxepunk/graphics/Spritemap.hx
+++ b/haxepunk/graphics/Spritemap.hx
@@ -1,6 +1,7 @@
 package haxepunk.graphics;
 
 import flash.geom.Rectangle;
+import haxe.ds.Either;
 import haxepunk.HXP;
 import haxepunk.Graphic;
 import haxepunk.graphics.atlas.TileAtlas;
@@ -43,7 +44,7 @@ class Spritemap extends Image
 		_timer = _frame = 0;
 
 		_rect = new Rectangle(0, 0, frameWidth, frameHeight);
-		switch (source.type)
+		switch (source)
 		{
 			case Left(bd):
 				super(bd, _rect);
@@ -122,7 +123,7 @@ class Spritemap extends Image
 				{
 					_timer--;
 					_index += reverse ? -1 : 1;
-					
+
 					if ((reverse && _index == -1) || (!reverse && _index == _anim.frameCount))
 					{
 						if (_anim.loop)
@@ -182,7 +183,7 @@ class Spritemap extends Image
 		{
 			return _anim;
 		}
-		
+
 		if (!_anims.exists(name))
 		{
 			stop(reset);
@@ -192,7 +193,7 @@ class Spritemap extends Image
 		_anim = _anims.get(name);
 		this.reverse = reverse;
 		restart();
-		
+
 		return _anim;
 	}
 
@@ -209,7 +210,7 @@ class Spritemap extends Image
 	{
 		if (frames == null || frames.length == 0)
 		{
-			stop(reset);		
+			stop(reset);
 			return null;
 		}
 
@@ -230,14 +231,14 @@ class Spritemap extends Image
 	{
 		if (anim == null)
 			throw "No animation supplied";
-			
+
 		if (!reset && _anim == anim)
 			return anim;
 
 		_anim = anim;
 		this.reverse = reverse;
 		restart();
-		
+
 		return anim;
 	}
 
@@ -260,7 +261,7 @@ class Spritemap extends Image
 	{
 		if (reset)
 			_frame = _index = reverse ? _anim.frames.length - 1 : 0;
-		
+
 		_anim = null;
 		complete = true;
 		updateBuffer();
@@ -318,7 +319,7 @@ class Spritemap extends Image
 	 * animations playing will be stopped to force the frame.
 	 */
 	public var frame(get, set):Int;
-	function get_frame():Int return _frame; 
+	function get_frame():Int return _frame;
 	function set_frame(value:Int):Int
 	{
 		_anim = null;
@@ -334,7 +335,7 @@ class Spritemap extends Image
 	 * Current index of the playing animation.
 	 */
 	public var index(get, set):Int;
-	function get_index():Int return _anim != null ? _index : 0; 
+	function get_index():Int return _anim != null ? _index : 0;
 	function set_index(value:Int):Int
 	{
 		if (_anim == null) return 0;
@@ -345,7 +346,7 @@ class Spritemap extends Image
 		updateBuffer();
 		return _index;
 	}
-	
+
 	/**
 	 * If the animation is played in reverse.
 	 */
@@ -355,25 +356,25 @@ class Spritemap extends Image
 	 * The amount of frames in the Spritemap.
 	 */
 	public var frameCount(get, null):Int;
-	function get_frameCount():Int return _frameCount; 
+	function get_frameCount():Int return _frameCount;
 
 	/**
 	 * Columns in the Spritemap.
 	 */
 	public var columns(get, null):Int;
-	function get_columns():Int return _columns; 
+	function get_columns():Int return _columns;
 
 	/**
 	 * Rows in the Spritemap.
 	 */
 	public var rows(get, null):Int;
-	function get_rows():Int return _rows; 
+	function get_rows():Int return _rows;
 
 	/**
 	 * The currently playing animation.
 	 */
 	public var currentAnim(get, null):String;
-	function get_currentAnim():String return (_anim != null) ? _anim.name : ""; 
+	function get_currentAnim():String return (_anim != null) ? _anim.name : "";
 
 	// Spritemap information.
 	var _rect:Rectangle;

--- a/haxepunk/graphics/Tilemap.hx
+++ b/haxepunk/graphics/Tilemap.hx
@@ -3,6 +3,7 @@ package haxepunk.graphics;
 import flash.display.BitmapData;
 import flash.geom.Point;
 import flash.geom.Rectangle;
+import haxe.ds.Either;
 import haxepunk.Graphic;
 import haxepunk.HXP;
 import haxepunk.graphics.atlas.TileAtlas;
@@ -70,7 +71,7 @@ class Tilemap extends Canvas
 		}
 
 		// load the tileset graphic
-		switch (tileset.type)
+		switch (tileset)
 		{
 			case Left(bd):
 				blit = true;

--- a/haxepunk/input/Input.hx
+++ b/haxepunk/input/Input.hx
@@ -6,8 +6,9 @@ import flash.events.TouchEvent;
 import flash.ui.Keyboard;
 import flash.ui.Multitouch;
 import flash.ui.MultitouchInputMode;
+import haxe.ds.Either;
 import haxepunk.HXP;
-import haxepunk.ds.Either;
+import haxepunk.ds.OneOf;
 import openfl.ui.Mouse;
 
 #if (openfl_legacy && (cpp || neko))
@@ -19,19 +20,7 @@ import tv.ouya.console.api.OuyaController;
 import openfl.utils.JNI;
 #end
 
-/**
- * Abstract representing either a `String` or a `Int`.
- * 
- * Conversion is automatic, no need to use this.
- */
-abstract InputType(Either<String, Int>)
-{
-	@:dox(hide) public inline function new(e:Either<String, Int>) this = e;
-	@:dox(hide) public var type(get, never):Either<String, Int>;
-	@:to inline function get_type() return this;
-	@:from static function fromLeft(v:String) return new InputType(Left(v));
-	@:from static function fromRight(v:Int) return new InputType(Right(v));
-}
+typedef InputType = OneOf<String, Int>;
 
 /**
  * Manage the different inputs.
@@ -203,7 +192,7 @@ class Input
 	 */
 	public static function check(input:InputType):Bool
 	{
-		switch (input.type)
+		switch (input)
 		{
 			case Left(s):
 #if debug
@@ -232,7 +221,7 @@ class Input
 	 */
 	public static function pressed(input:InputType):Bool
 	{
-		switch (input.type)
+		switch (input)
 		{
 			case Left(s):
 				if (_control.exists(s))
@@ -255,7 +244,7 @@ class Input
 	 */
 	public static function released(input:InputType):Bool
 	{
-		switch (input.type)
+		switch (input)
 		{
 			case Left(s):
 				for (key in _control.get(s))
@@ -277,10 +266,10 @@ class Input
 	}
 
 	public static var touches(get, never):Map<Int, Touch>;
-	static inline function get_touches():Map<Int, Touch> return _touches; 
+	static inline function get_touches():Map<Int, Touch> return _touches;
 
 	public static var touchOrder(get, never):Array<Int>;
-	static inline function get_touchOrder():Array<Int> return _touchOrder; 
+	static inline function get_touchOrder():Array<Int> return _touchOrder;
 
 	/**
 	 * Returns a joystick object (creates one if not connected)
@@ -432,9 +421,9 @@ class Input
 		if (multiTouchSupported)
 		{
 			for (touch in _touches) touch.update();
-			
+
 			if (Gesture.enabled) Gesture.update();
-			
+
 			for (touch in _touches)
 			{
 				if (touch.released && !touch.pressed)


### PR DESCRIPTION
Simplifies SolidType and InputType using the OneOf class. I also removed the `type` variable from the graphics classes and make the "from" methods cleaner.

This results in cleaner code generation but could impact external code if someone is using the abstract types.