### PR TITLE
Rich BitmapText

### DIFF
--- a/haxepunk/HXP.hx
+++ b/haxepunk/HXP.hx
@@ -34,11 +34,6 @@ class HXP
 	public static inline var VERSION:String = HaxelibInfo.version;
 
 	/**
-	 * Deprecated, use 0 instead. The color black (as an Int).
-	 */
-	@:deprecated public static inline var blackColor:Color = 0x00000000;
-
-	/**
 	 * Width of the game.
 	 */
 	public static var width:Int;

--- a/haxepunk/graphics/BitmapText.hx
+++ b/haxepunk/graphics/BitmapText.hx
@@ -142,6 +142,13 @@ class BitmapText extends Graphic
 	public var lineSpacing:Int = 0;
 	public var charSpacing:Int = 0;
 
+	/**
+	 * How many characters of text to render. If -1, render the entire string;
+	 * if less than the number of visible characters, will end early. Images
+	 * and line breaks count as one character each.
+	 */
+	public var displayCharCount:Int = -1;
+
 	var opCodes:Array<TextOpcode> = new Array();
 
 	/**
@@ -498,9 +505,11 @@ class BitmapText extends Graphic
 			currentScale:Float = 1,
 			cursorX:Float = 0,
 			cursorY:Float = 0,
-			thisLineHeight:Float = lineHeight * sy;
+			thisLineHeight:Float = lineHeight * sy,
+			charCount:Int = 0;
 		for (op in opCodes)
 		{
+			if (displayCharCount > -1 && charCount >= displayCharCount) break;
 			switch (op)
 			{
 				case SetColor(color):
@@ -523,6 +532,8 @@ class BitmapText extends Graphic
 					// render a block of text on this line
 					for (i in 0 ... text.length)
 					{
+						if (displayCharCount > -1 && charCount >= displayCharCount) break;
+						++charCount;
 						var char = text.charAt(i);
 						var region = _font.getChar(char);
 						var gd = _font.glyphData.get(char);
@@ -558,6 +569,7 @@ class BitmapText extends Graphic
 					cursorX = 0;
 					cursorY += thisLineHeight;
 					thisLineHeight = lineHeight * sy * currentScale;
+					++charCount;
 				case Image(img):
 					if (renderImageFunction != null)
 					{
@@ -566,6 +578,7 @@ class BitmapText extends Graphic
 					thisLineHeight = Std.int(Math.max(thisLineHeight, img.height * img.scale * img.scaleY));
 					cursorX += (img.width * img.scale * img.scaleX * this.scale * this.scaleX * currentScale) + charSpacing * sx * currentScale;
 					if (cursorX > textWidth) textWidth = Std.int(cursorX);
+					++charCount;
 			}
 		}
 		textHeight = Std.int(cursorY + (cursorX > 0 ? thisLineHeight : 0));

--- a/haxepunk/graphics/atlas/BitmapFontAtlas.hx
+++ b/haxepunk/graphics/atlas/BitmapFontAtlas.hx
@@ -167,7 +167,7 @@ class BitmapFontAtlas extends TextureAtlas
 
 			while (cx < bmd.width && letterIdx < alphabetLength)
 			{
-				if (Std.int(bmd.getPixel(cx, cy)) != globalBGColor) 
+				if (Std.int(bmd.getPixel(cx, cy)) != globalBGColor)
 				{
 					// found non bg pixel
 					var gx:Int = cx;
@@ -194,11 +194,11 @@ class BitmapFontAtlas extends TextureAtlas
 					// set the defined region
 					var region = atlas.defineRegion(glyph, HXP.rect);
 					atlas.glyphData[glyph] = md;
-					
+
 					// store max size
 					if (gh > rowHeight) rowHeight = gh;
 					if (gh > atlas.fontSize) atlas.fontSize = gh;
-					
+
 					// go to next glyph
 					cx += gw;
 					letterIdx++;
@@ -232,7 +232,7 @@ class BitmapFontAtlas extends TextureAtlas
 	 * Returns an AtlasRegion for a given character, or whitespace if that
 	 * character is not found.
 	 */
-	public function getChar(name:String):AtlasRegion
+	public inline function getChar(name:String):AtlasRegion
 	{
 		try
 		{

--- a/haxepunk/graphics/atlas/TextureAtlas.hx
+++ b/haxepunk/graphics/atlas/TextureAtlas.hx
@@ -73,11 +73,11 @@ class TextureAtlas extends Atlas
 	 *
 	 * @return	The retrieved region.
 	 */
-	public function getRegion(name:String):AtlasRegion
+	public inline function getRegion(name:String):AtlasRegion
 	{
 		if (_regions.exists(name))
 			return _regions.get(name);
-			
+
 		throw 'Region has not been defined yet "$name".';
 	}
 


### PR DESCRIPTION
BitmapText can define format markup tags which affect a subset of the text as well as custom image tags which are rendered inline with the text. Also added a `displayCharCount` for gradually revealed text.

```
BitmapText.defineFormatTag("green", 0x55d400);
BitmapText.defineFormatTag("blue", 0x5f8dd3);
BitmapText.defineImageTag("my-img", new Image("assets/graphics/testimage.png"));

var txt = new BitmapText("Supports <green>colored</green> <blue>text</blue> and images: <my-img/>", 0, 0, 0, 0, {font: 'assets/fonts/myfont.fnt', size: 16});
```

TODO:

- [x] Create demo including tests of word wrapping