### PR TITLE
Reduce GC from HXP.clear.

### DIFF
--- a/haxepunk/HXP.hx
+++ b/haxepunk/HXP.hx
@@ -223,10 +223,12 @@ class HXP
 	 * Empties an array of its' contents
 	 * @param array filled array
 	 */
-	public static inline function clear(array:Array<Dynamic>)
+	@:generic public static inline function clear<T>(array:Array<T>)
 	{
-#if (cpp || php)
-		array.splice(0, array.length);
+#if cpp
+		// splice causes Array allocation, so prefer pop for most arrays
+		if (array.length > 256) array.splice(0, array.length);
+		else while (array.length > 0) array.pop();
 #else
 		untyped array.length = 0;
 #end


### PR DESCRIPTION
Benchmarked this locally and the pop method takes 50x as long for an array of 256 ints. Since this method is very unlikely to be taking significant amounts of CPU time (time to clear an array of 256 ints on my laptop was 2.64637470245361e-06 seconds) and this eliminates the extra array allocations, I think this is a good tradeoff until Haxe provides a saner way of clearing arrays.

For reference, HaxeFlixel is using pop to clear arrays too: https://github.com/HaxeFlixel/flixel/blob/master/flixel/util/FlxArrayUtil.hx#L93. Since the ratio of pop time / splice time gets worse as the size of the array gets larger, I think the heuristic makes sense.