### PR TITLE
Adding default values to Graphic constructor

### DIFF
--- a/haxepunk/Graphic.hx
+++ b/haxepunk/Graphic.hx
@@ -159,8 +159,7 @@ class Graphic
 	/**
 	 * Change the opacity of the Image, a value from 0 to 1.
 	 */
-	@:isVar public var alpha(get_alpha, set_alpha):Float = 1;
-	inline function get_alpha():Float return alpha;
+	public var alpha(default, set):Float = 1;
 	function set_alpha(value:Float):Float
 	{
 		return alpha = value < 0 ? 0 : (value > 1 ? 1 : value);
@@ -169,18 +168,16 @@ class Graphic
 	/**
 	 * The tinted color of the Image. Use 0xFFFFFF to draw the Image normally.
 	 */
-	@:isVar public var color(get_color, set_color):Color = Color.White;
-	inline function get_color():Color return color;
+	public var color(default, set):Color;
 	function set_color(value:Color):Color
 	{
 		value &= 0xFFFFFF;
 		if (color == value) return value;
-		color = value;
 		// save individual color channel values
-		_red = color.red;
-		_green = color.green;
-		_blue = color.blue;
-		return color;
+		_red = value.red;
+		_green = value.green;
+		_blue = value.blue;
+		return color = value;
 	}
 
 	/**
@@ -212,7 +209,11 @@ class Graphic
 	 * Constructor.
 	 */
 	@:allow(haxepunk)
-	function new() {}
+	function new()
+	{
+		smooth = (HXP.stage.quality != LOW);
+		color = Color.White;
+	}
 
 	/**
 	 * Updates the graphic.

--- a/haxepunk/graphics/Backdrop.hx
+++ b/haxepunk/graphics/Backdrop.hx
@@ -42,9 +42,6 @@ class Backdrop extends Graphic
 		_repeatX = repeatX;
 		_repeatY = repeatY;
 
-		color = 0xFFFFFF;
-		alpha = 1;
-
 		super();
 	}
 

--- a/haxepunk/graphics/BaseEmitter.hx
+++ b/haxepunk/graphics/BaseEmitter.hx
@@ -26,7 +26,6 @@ import haxepunk.utils.Random;
 		_types = new Map<String, ParticleType>();
 		active = true;
 		particleCount = 0;
-		smooth = (HXP.stage.quality != LOW);
 	}
 
 	override public function render(layer:Int, point:Point, camera:Camera)

--- a/haxepunk/graphics/BitmapText.hx
+++ b/haxepunk/graphics/BitmapText.hx
@@ -268,8 +268,6 @@ class BitmapText extends Graphic
 
 		this.color = options.color;
 		this.text = text != null ? text : "";
-
-		smooth = (HXP.stage.quality != LOW);
 	}
 
 	public var text(default, set):String;

--- a/haxepunk/graphics/Image.hx
+++ b/haxepunk/graphics/Image.hx
@@ -80,8 +80,6 @@ class Image extends Graphic
 			_region = _region.clip(clipRect); // create a new clipped region
 			_sourceRect = clipRect;
 		}
-
-		smooth = (HXP.stage.quality != LOW);
 	}
 
 	/** @private Initialize variables */

--- a/haxepunk/graphics/Tilemap.hx
+++ b/haxepunk/graphics/Tilemap.hx
@@ -65,8 +65,6 @@ class Tilemap extends Graphic
 		super();
 		this.width = width - (width % tileWidth);
 		this.height = height - (height % tileHeight);
-		color = 0xFFFFFF;
-		alpha = 1;
 		_columns = Std.int(this.width / tileWidth);
 		_rows = Std.int(this.height / tileHeight);
 
@@ -101,8 +99,6 @@ class Tilemap extends Graphic
 		_setColumns = Std.int(_atlas.width / tileWidth);
 		_setRows = Std.int(_atlas.height / tileHeight);
 		_setCount = _setColumns * _setRows;
-
-		smooth = (HXP.stage.quality != LOW);
 	}
 
 	/**


### PR DESCRIPTION
Graphic should set smooth and color defaults instead of in descendants. Haxe set functions aren't called when properties have default values which is why I moved the color assignment to the constructor.