### PR TITLE
Shader argument order consistency.

### DIFF
--- a/haxepunk/graphics/Backdrop.hx
+++ b/haxepunk/graphics/Backdrop.hx
@@ -81,9 +81,9 @@ class Backdrop extends Graphic
 				_region.draw(
 					px + x * scaledWidth,
 					py + y * scaledHeight,
-					layer, shader, sx, sy, 0,
+					layer, sx, sy, 0,
 					_red, _green, _blue, alpha,
-					smooth, blend
+					shader, smooth, blend
 				);
 			}
 		}

--- a/haxepunk/graphics/BitmapText.hx
+++ b/haxepunk/graphics/BitmapText.hx
@@ -544,8 +544,9 @@ class BitmapText extends Graphic
 								y = point.y + gd.yOffset * gd.scale * sy / maxFullScale + thisLineHeight - (lineHeight * currentScale);
 							gd.region.draw(
 								(_point.x + x) * fsx, (_point.y + y) * fsy,
-								layer, shader, gd.scale, gd.scale * sy * fsy / maxFullScale, 0,
-								currentColor.red, currentColor.green, currentColor.blue, currentAlpha, smooth, blend
+								layer, gd.scale, gd.scale * sy * fsy / maxFullScale, 0,
+								currentColor.red, currentColor.green, currentColor.blue, currentAlpha,
+								shader, smooth, blend
 							);
 							// advance cursor position
 							cursorX += gd.xAdvance * gd.scale / fsx + charSpacing * currentScale;

--- a/haxepunk/graphics/Image.hx
+++ b/haxepunk/graphics/Image.hx
@@ -116,7 +116,11 @@ class Image extends Graphic
 
 			// render without rotation
 			var clipRect = screenClipRect(_point.x, _point.y);
-			_region.draw(_point.x * fsx, _point.y * fsy, layer, shader, sx * fsx, sy * fsy, angle, _red, _green, _blue, alpha, smooth, blend, clipRect);
+			_region.draw(_point.x * fsx, _point.y * fsy,
+				layer, sx * fsx, sy * fsy, angle,
+				_red, _green, _blue, alpha,
+				shader, smooth, blend, clipRect
+			);
 		}
 		else
 		{
@@ -130,7 +134,10 @@ class Image extends Graphic
 			var tx = (-originX * sx * cos + originY * sy * sin + originX + _point.x);
 			var ty = (-originX * sx * sin - originY * sy * cos + originY + _point.y);
 			var clipRect = screenClipRect(tx, ty);
-			_region.drawMatrix(tx * fsx, ty * fsy, a, b, c, d, layer, shader, _red, _green, _blue, alpha, smooth, blend, clipRect);
+			_region.drawMatrix(tx * fsx, ty * fsy, a, b, c, d, layer,
+				_red, _green, _blue, alpha,
+				shader, smooth, blend, clipRect
+			);
 		}
 	}
 

--- a/haxepunk/graphics/TiledImage.hx
+++ b/haxepunk/graphics/TiledImage.hx
@@ -46,9 +46,9 @@ class TiledImage extends Image
 			while (x < _width)
 			{
 				_region.draw(Math.floor((_point.x + x) * fsx), Math.floor((_point.y + y) * fsy),
-					layer, shader, sx, sy, angle,
+					layer, sx, sy, angle,
 					_red, _green, _blue, alpha,
-					smooth, blend
+					shader, smooth, blend
 					);
 				x += _sourceRect.width;
 			}

--- a/haxepunk/graphics/TiledSpritemap.hx
+++ b/haxepunk/graphics/TiledSpritemap.hx
@@ -43,9 +43,9 @@ class TiledSpritemap extends Spritemap
 			while (x < _imageWidth)
 			{
 				_region.draw(Math.floor((_point.x + x) * fsx), Math.floor((_point.y + y) * fsy),
-					layer, shader, sx, sy, angle,
+					layer, sx, sy, angle,
 					_red, _green, _blue, alpha,
-					smooth, blend
+					shader, smooth, blend
 				);
 				x += _sourceRect.width;
 			}

--- a/haxepunk/graphics/Tilemap.hx
+++ b/haxepunk/graphics/Tilemap.hx
@@ -441,7 +441,11 @@ class Tilemap extends Graphic
 					scx = (Math.floor(nx) - Math.floor(wx)) / tileWidth;
 
 					updateTileRect(tile);
-					_atlas.prepareTile(_tile, Math.floor(_point.x + wx), Math.floor(_point.y + wy), layer, shader, scx, scy, 0, _red, _green, _blue, alpha, smooth, blend);
+					_atlas.prepareTile(_tile, Math.floor(_point.x + wx), Math.floor(_point.y + wy), layer,
+						scx, scy, 0,
+						_red, _green, _blue, alpha,
+						shader, smooth, blend
+					);
 				}
 				wx = nx;
 			}

--- a/haxepunk/graphics/atlas/Atlas.hx
+++ b/haxepunk/graphics/atlas/Atlas.hx
@@ -63,11 +63,11 @@ class Atlas
 	 * @param	alpha	The tile's opacity
 	 */
 	public inline function prepareTile(rect:Rectangle, x:Float, y:Float, layer:Int,
-		shader:Shader, scaleX:Float, scaleY:Float, angle:Float,
+		scaleX:Float, scaleY:Float, angle:Float,
 		red:Float, green:Float, blue:Float, alpha:Float,
-		smooth:Bool, blend:BlendMode)
+		shader:Shader, smooth:Bool, blend:BlendMode, ?clipRect:Rectangle)
 	{
-		_data.prepareTile(shader, rect, x, y, layer, scaleX, scaleY, angle, red, green, blue, alpha, smooth, blend);
+		_data.prepareTile(rect, x, y, layer, scaleX, scaleY, angle, red, green, blue, alpha, shader, smooth, blend, clipRect);
 	}
 
 	/**

--- a/haxepunk/graphics/atlas/AtlasData.hx
+++ b/haxepunk/graphics/atlas/AtlasData.hx
@@ -175,11 +175,10 @@ class AtlasData
 	 * @param  alpha Alpha value
 	 */
 	public inline function prepareTileMatrix(
-		shader:Shader,
 		rect:Rectangle, layer:Int,
 		tx:Float, ty:Float, a:Float, b:Float, c:Float, d:Float,
 		red:Float, green:Float, blue:Float, alpha:Float,
-		smooth:Bool=false, blend:BlendMode, ?clipRect:Rectangle)
+		shader:Shader, smooth:Bool=false, blend:BlendMode, ?clipRect:Rectangle)
 	{
 		var batch = _scene.sprite.batch;
 		batch.addRect(
@@ -205,11 +204,10 @@ class AtlasData
 	 * @param  alpha  Alpha value
 	 */
 	public inline function prepareTile(
-		shader:Shader,
 		rect:Rectangle, tx:Float, ty:Float, layer:Int,
 		scaleX:Float, scaleY:Float, angle:Float,
 		red:Float, green:Float, blue:Float, alpha:Float,
-		smooth:Bool, blend:BlendMode, ?clipRect:Rectangle):Void
+		shader:Shader, smooth:Bool, blend:BlendMode, ?clipRect:Rectangle):Void
 	{
 		var a:Float, b:Float, c:Float, d:Float;
 
@@ -237,12 +235,11 @@ class AtlasData
 	}
 
 	public function prepareTriangle(
-		shader:Shader,
 		tx1:Float, ty1:Float, uvx1:Float, uvy1:Float,
 		tx2:Float, ty2:Float, uvx2:Float, uvy2:Float,
 		tx3:Float, ty3:Float, uvx3:Float, uvy3:Float,
 		red:Float, green:Float, blue:Float, alpha:Float,
-		smooth:Bool, blend:BlendMode, ?clipRect:Rectangle):Void
+		shader:Shader, smooth:Bool, blend:BlendMode, ?clipRect:Rectangle):Void
 	{
 		var batch = _scene.sprite.batch;
 		batch.addTriangle(bitmapData, shader, smooth, blend, clipRect, tx1, ty1, uvx1, uvy1, tx2, ty2, uvx2, uvy2, tx3, ty3, uvx3, uvy3, red, green, blue, alpha);

--- a/haxepunk/graphics/atlas/AtlasRegion.hx
+++ b/haxepunk/graphics/atlas/AtlasRegion.hx
@@ -81,17 +81,17 @@ class AtlasRegion implements IAtlasRegion
 	 * @param	blend		Blend mode
 	 * @param	clipRect	Clipping rectangle
 	 */
-	public inline function draw(x:Float, y:Float, layer:Int, shader:Shader,
+	public inline function draw(x:Float, y:Float, layer:Int,
 		scaleX:Float=1, scaleY:Float=1, angle:Float=0,
 		red:Float=1, green:Float=1, blue:Float=1, alpha:Float=1,
-		smooth:Bool, blend:BlendMode, ?clipRect:Rectangle)
+		shader:Shader, smooth:Bool, blend:BlendMode, ?clipRect:Rectangle)
 	{
 		if (rotated) angle = angle + 90;
 
-		_parent.prepareTile(shader, _rect, x, y, layer,
+		_parent.prepareTile(_rect, x, y, layer,
 			scaleX, scaleY, angle,
 			red, green, blue, alpha,
-			smooth, blend, clipRect);
+			shader, smooth, blend, clipRect);
 	}
 
 	/**
@@ -113,21 +113,26 @@ class AtlasRegion implements IAtlasRegion
 	 * @param	clipRect	Clipping rectangle
 	 */
 	public inline function drawMatrix(tx:Float, ty:Float, a:Float, b:Float, c:Float, d:Float,
-		layer:Int, shader:Shader, red:Float=1, green:Float=1, blue:Float=1, alpha:Float=1,
-		smooth:Bool, blend:BlendMode, ?clipRect:Rectangle):Void
+		layer:Int, red:Float=1, green:Float=1, blue:Float=1, alpha:Float=1,
+		shader:Shader, smooth:Bool, blend:BlendMode, ?clipRect:Rectangle):Void
 	{
 		if (rotated)
 		{
 			var matrix = new Matrix(a, b, c, d, tx, ty);
 			matrix.rotate(90 * MathUtil.RAD);
-			_parent.prepareTileMatrix(shader, _rect, layer,
+			_parent.prepareTileMatrix(_rect, layer,
 				matrix.tx, matrix.ty, matrix.a, matrix.b, matrix.c, matrix.d,
-				red, green, blue, alpha, smooth, blend, clipRect);
+				red, green, blue, alpha,
+				shader, smooth, blend, clipRect
+			);
 		}
 		else
 		{
-			_parent.prepareTileMatrix(shader, _rect, layer, tx, ty, a, b, c, d,
-				red, green, blue, alpha, smooth, blend, clipRect);
+			_parent.prepareTileMatrix(_rect, layer,
+				tx, ty, a, b, c, d,
+				red, green, blue, alpha,
+				shader, smooth, blend, clipRect
+			);
 		}
 	}
 

--- a/haxepunk/graphics/atlas/AtlasResolutions.hx
+++ b/haxepunk/graphics/atlas/AtlasResolutions.hx
@@ -75,13 +75,17 @@ class AtlasResolutions implements IAtlasRegion
 	 * @param	clipRect	Clipping rectangle
 	 */
 	public inline function draw(x:Float, y:Float, layer:Int,
-		shader:Shader, scaleX:Float=1, scaleY:Float=1, angle:Float=0,
+		scaleX:Float=1, scaleY:Float=1, angle:Float=0,
 		red:Float=1, green:Float=1, blue:Float=1, alpha:Float=1,
-		smooth:Bool, blend:BlendMode, ?clipRect:Rectangle)
+		shader:Shader, smooth:Bool, blend:BlendMode, ?clipRect:Rectangle)
 	{
 		var region = regionForScale(Math.max(Math.abs(scaleX), Math.abs(scaleY)));
 		var scale:Float = base.width / region.width;
-		region.draw(x, y, layer, shader, scaleX * scale, scaleY * scale, angle, red, green, blue, alpha, smooth, blend, clipRect);
+		region.draw(x, y, layer,
+			scaleX * scale, scaleY * scale, angle,
+			red, green, blue, alpha,
+			shader, smooth, blend, clipRect
+		);
 	}
 
 	/**
@@ -102,12 +106,15 @@ class AtlasResolutions implements IAtlasRegion
 	 * @param	clipRect	Clipping rectangle
 	 */
 	public inline function drawMatrix(tx:Float, ty:Float, a:Float, b:Float, c:Float, d:Float,
-		layer:Int, shader:Shader, red:Float=1, green:Float=1, blue:Float=1, alpha:Float=1,
-		smooth:Bool, blend:BlendMode, ?clipRect:Rectangle)
+		layer:Int, red:Float=1, green:Float=1, blue:Float=1, alpha:Float=1,
+		shader:Shader, smooth:Bool, blend:BlendMode, ?clipRect:Rectangle)
 	{
 		var region = regionForScale(Math.max(Math.abs(a * c), Math.abs(b * d)));
 		var scale:Float = base.width / region.width;
-		region.drawMatrix(tx * scale, ty * scale, a * scale, b * scale, c * scale, d * scale, layer, shader, red, green, blue, alpha, smooth, blend, clipRect);
+		region.drawMatrix(tx * scale, ty * scale, a * scale, b * scale, c * scale, d * scale, layer,
+			red, green, blue, alpha,
+			shader, smooth, blend, clipRect
+		);
 	}
 
 	public function clip(clipRect:Rectangle, ?center:Point):IAtlasRegion

--- a/haxepunk/graphics/atlas/IAtlasRegion.hx
+++ b/haxepunk/graphics/atlas/IAtlasRegion.hx
@@ -10,14 +10,14 @@ interface IAtlasRegion
 	public var width(get, never):Int;
 	public var height(get, never):Int;
 
-	public function draw(x:Float, y:Float, layer:Int, shader:Shader,
+	public function draw(x:Float, y:Float, layer:Int,
 		scaleX:Float=1, scaleY:Float=1, angle:Float=0,
 		red:Float=1, green:Float=1, blue:Float=1, alpha:Float=1,
-		smooth:Bool, blend:BlendMode, ?clipRect:Rectangle):Void;
+		shader:Shader, smooth:Bool, blend:BlendMode, ?clipRect:Rectangle):Void;
 
 	public function drawMatrix(tx:Float, ty:Float, a:Float, b:Float, c:Float, d:Float,
-		layer:Int, shader:Shader, red:Float=1, green:Float=1, blue:Float=1, alpha:Float=1,
-		smooth:Bool, blend:BlendMode, ?clipRect:Rectangle):Void;
+		layer:Int, red:Float=1, green:Float=1, blue:Float=1, alpha:Float=1,
+		shader:Shader, smooth:Bool, blend:BlendMode, ?clipRect:Rectangle):Void;
 
 	public function clip(clipRect:Rectangle, ?center:Point):IAtlasRegion;
 	public function destroy():Void;


### PR DESCRIPTION
The place that the new `shader` argument shows up in the various rendering functions is inconsistent (sometimes first, sometimes after layer.) This updates them all to follow the order DrawCommand uses - all of the args that determine which DrawCommand to use (shader, smooth, blend, clipRect) always appear together in the same order.