### PR TITLE
Fixed C++ crash on most accesses to Spritemap

### DIFF
--- a/haxepunk/graphics/Spritemap.hx
+++ b/haxepunk/graphics/Spritemap.hx
@@ -270,7 +270,7 @@ class Spritemap extends Image
 	/**
 	 * Sets the current frame index.
 	 */
-	public var frame(default, set):Int;
+	public var frame(default, set):Int = -1;
 	function set_frame(value:Int):Int
 	{
 		value = Std.int(Math.abs(value)) % _atlas.tileCount;


### PR DESCRIPTION
The C++ target having initialized the `frame` value to 0, line 102 did not refresh the _region object, which then remained null until the frame was set again, thus resulting in a null pointer exception (somehow, not reported ?) and a silent crash everytime the _region object was used (this includes render() and get_width() / get_height()). Initializing `frame` to -1 fixed this crash.