### PR TITLE
Fix Scene.camera getting reset every frame

### DIFF
--- a/haxepunk/graphics/Graphiclist.hx
+++ b/haxepunk/graphics/Graphiclist.hx
@@ -50,12 +50,11 @@ class Graphiclist extends Graphic
 		else return _graphics[i];
 	}
 
-	inline function renderList(renderFunc:Graphic->Void, point:Point, camera:Camera)
+	inline function renderList(renderFunc:Graphic->Void, point:Point, topCamera:Camera)
 	{
 		point.x += x;
 		point.y += y;
-		camera.x *= scrollX;
-		camera.y *= scrollY;
+		var camera = new Point(topCamera.x * scrollX, topCamera.y * scrollY);
 
 		for (g in _graphics)
 		{


### PR DESCRIPTION
When a Graphiclist was effectively being rendered, its parent Entity's Scene saw its camera attribute get reset to (0, 0).

I cannot stress enough how annoying this was to find and fix. Took me 6 hours.