### PR TITLE
More Tween unit tests

### DIFF
--- a/haxepunk/Engine.hx
+++ b/haxepunk/Engine.hx
@@ -138,10 +138,10 @@ class Engine extends Sprite
 
 		preUpdate.invoke();
 
-		if (HXP.tweener.active && HXP.tweener.hasTween) HXP.tweener.updateTweens();
+		if (HXP.tweener.active && HXP.tweener.hasTween) HXP.tweener.updateTweens(HXP.elapsed);
 		if (_scene.active)
 		{
-			if (_scene.hasTween) _scene.updateTweens();
+			if (_scene.hasTween) _scene.updateTweens(HXP.elapsed);
 			_scene.update();
 		}
 		_scene.updateLists(false);

--- a/haxepunk/Scene.hx
+++ b/haxepunk/Scene.hx
@@ -153,7 +153,7 @@ class Scene extends Tweener
 		{
 			if (e.active)
 			{
-				if (e.hasTween) e.updateTweens();
+				if (e.hasTween) e.updateTweens(HXP.elapsed);
 				if (e.active) e.update();
 			}
 			if (e.graphic != null && e.graphic.active) e.graphic.update();

--- a/haxepunk/Tween.hx
+++ b/haxepunk/Tween.hx
@@ -88,6 +88,10 @@ class Tween extends EventDispatcher
 			}
 			dispatchEvent(new TweenEvent(TweenEvent.UPDATE));
 		}
+		if (_finish)
+		{
+			finish();
+		}
 	}
 
 	/**

--- a/haxepunk/Tween.hx
+++ b/haxepunk/Tween.hx
@@ -74,11 +74,11 @@ class Tween extends EventDispatcher
 	 * Updates the Tween, called by World.
 	 */
 	@:dox(hide)
-	public function update()
+	public function update(elapsed:Float)
 	{
 		if (active)
 		{
-			_time += HXP.elapsed;
+			_time += elapsed;
 			_t = percent;
 			if (_t > 0 && _t < 1) _ease.may(function(f) _t = f(_t));
 			if (_time >= _target)

--- a/haxepunk/Tweener.hx
+++ b/haxepunk/Tweener.hx
@@ -83,12 +83,12 @@ class Tweener
 	 */
 	public function clearTweens()
 	{
-		var t:Tween,
-			ft:Tween = _tween;
-		while (ft != null)
+		var t:Tween = _tween;
+		while (t != null)
 		{
-			removeTween(ft._next);
-			ft = ft._next;
+			var next = t._next;
+			removeTween(t);
+			t = next;
 		}
 	}
 
@@ -97,17 +97,14 @@ class Tweener
 	 */
 	public function updateTweens(elapsed:Float)
 	{
-		var t:Tween,
-			ft:Tween = _tween;
-		while (ft != null)
+		var t:Tween = _tween;
+		while (t != null)
 		{
-			t = cast(ft, Tween);
 			if (t.active)
 			{
 				t.update(elapsed);
-				if (ft._finish) ft.finish();
 			}
-			ft = ft._next;
+			t = t._next;
 		}
 	}
 

--- a/haxepunk/Tweener.hx
+++ b/haxepunk/Tweener.hx
@@ -95,7 +95,7 @@ class Tweener
 	/**
 	 * Update all contained tweens.
 	 */
-	public function updateTweens()
+	public function updateTweens(elapsed:Float)
 	{
 		var t:Tween,
 			ft:Tween = _tween;
@@ -104,7 +104,7 @@ class Tweener
 			t = cast(ft, Tween);
 			if (t.active)
 			{
-				t.update();
+				t.update(elapsed);
 				if (ft._finish) ft.finish();
 			}
 			ft = ft._next;

--- a/haxepunk/tweens/misc/AngleTween.hx
+++ b/haxepunk/tweens/misc/AngleTween.hx
@@ -13,18 +13,18 @@ class AngleTween extends Tween
 	 * The current value.
 	 */
 	public var angle:Float;
-	
+
 	/**
 	 * Constructor.
 	 * @param	complete	Optional completion callback.
 	 * @param	type		Tween type.
 	 */
-	public function new(?complete:Dynamic -> Void, type:TweenType) 
+	public function new(?complete:Dynamic -> Void, type:TweenType)
 	{
 		angle = 0;
 		super(0, type, complete);
 	}
-	
+
 	/**
 	 * Tweens the value from one angle to another.
 	 * @param	fromAngle		Start angle.
@@ -44,16 +44,16 @@ class AngleTween extends Tween
 		_ease = ease;
 		start();
 	}
-	
+
 	/** @private Updates the Tween. */
 	@:dox(hide)
-	override public function update() 
+	override public function update(elapsed:Float)
 	{
-		super.update();
+		super.update(elapsed);
 		angle = (_start + _range * _t) % 360;
 		if (angle < 0) angle += 360;
 	}
-	
+
 	// Tween information.
 	var _start:Float;
 	var _range:Float;

--- a/haxepunk/tweens/misc/ColorTween.hx
+++ b/haxepunk/tweens/misc/ColorTween.hx
@@ -64,9 +64,9 @@ class ColorTween extends Tween
 
 	/** @private Updates the Tween. */
 	@:dox(hide)
-	override public function update()
+	override public function update(elapsed:Float)
 	{
-		super.update();
+		super.update(elapsed);
 		alpha = _startA + _rangeA * _t;
 		red = Std.int((_startR + _rangeR * _t) * 255);
 		green = Std.int((_startG + _rangeG * _t) * 255);

--- a/haxepunk/tweens/misc/MultiVarTween.hx
+++ b/haxepunk/tweens/misc/MultiVarTween.hx
@@ -65,9 +65,9 @@ class MultiVarTween extends Tween
 
 	/** @private Updates the Tween. */
 	@:dox(hide)
-	override public function update()
+	override public function update(elapsed:Float)
 	{
-		super.update();
+		super.update(elapsed);
 		var i:Int = _vars.length;
 
 		while (i-- > 0)

--- a/haxepunk/tweens/misc/MultiVarTween.hx
+++ b/haxepunk/tweens/misc/MultiVarTween.hx
@@ -54,7 +54,7 @@ class MultiVarTween extends Tween
 
 			if (Math.isNaN(a))
 			{
-				throw "The property \"" + p + "\" is not numeric.";
+				throw 'The property $p is not numeric.';
 			}
 			_vars.push(p);
 			_start.push(a);

--- a/haxepunk/tweens/misc/NumTween.hx
+++ b/haxepunk/tweens/misc/NumTween.hx
@@ -12,18 +12,18 @@ class NumTween extends Tween
 	 * The current value.
 	 */
 	public var value:Float;
-	
+
 	/**
 	 * Constructor.
 	 * @param	complete	Optional completion callback.
 	 * @param	type		Tween type.
 	 */
-	public function new(?complete:Dynamic -> Void, ?type:TweenType) 
+	public function new(?complete:Dynamic -> Void, ?type:TweenType)
 	{
 		value = 0;
 		super(0, type, complete);
 	}
-	
+
 	/**
 	 * Tweens the value from one value to another.
 	 * @param	fromValue		Start value.
@@ -39,15 +39,15 @@ class NumTween extends Tween
 		_ease = ease;
 		start();
 	}
-	
+
 	/** @private Updates the Tween. */
 	@:dox(hide)
-	override public function update() 
+	override public function update(elapsed:Float)
 	{
-		super.update();
+		super.update(elapsed);
 		value = _start + _range * _t;
 	}
-	
+
 	// Tween information.
 	var _start:Float;
 	var _range:Float;

--- a/haxepunk/tweens/misc/VarTween.hx
+++ b/haxepunk/tweens/misc/VarTween.hx
@@ -41,7 +41,7 @@ class VarTween extends Tween
 		// Check if the variable is a number
 		if (Math.isNaN(a))
 		{
-			throw "The property \"" + property + "\" is not numeric.";
+			throw 'The property $property is not numeric.';
 		}
 
 		_start = a;
@@ -52,9 +52,9 @@ class VarTween extends Tween
 
 	/** @private Updates the Tween. */
 	@:dox(hide)
-	override public function update()
+	override public function update(elapsed:Float)
 	{
-		super.update();
+		super.update(elapsed);
 		Reflect.setProperty(_object, _property, _start + _range * _t);
 	}
 

--- a/haxepunk/tweens/motion/CircularMotion.hx
+++ b/haxepunk/tweens/motion/CircularMotion.hx
@@ -71,9 +71,9 @@ class CircularMotion extends Motion
 
 	/** @private Updates the Tween. */
 	@:dox(hide)
-	override public function update()
+	override public function update(elapsed:Float)
 	{
-		super.update();
+		super.update(elapsed);
 		angle = _angleStart + _angleFinish * _t;
 		x = _centerX + Math.cos(angle) * _radius;
 		y = _centerY + Math.sin(angle) * _radius;

--- a/haxepunk/tweens/motion/CubicMotion.hx
+++ b/haxepunk/tweens/motion/CubicMotion.hx
@@ -51,9 +51,9 @@ class CubicMotion extends Motion
 
 	/** @private Updates the Tween. */
 	@:dox(hide)
-	override public function update()
+	override public function update(elapsed:Float)
 	{
-		super.update();
+		super.update(elapsed);
 		x = _t * _t * _t * (_toX + 3 * (_aX - _bX) - _fromX) + 3 * _t * _t * (_fromX - 2 * _aX + _bX) + 3 * _t * (_aX - _fromX) + _fromX;
 		y = _t * _t * _t * (_toY + 3 * (_aY - _bY) - _fromY) + 3 * _t * _t * (_fromY - 2 * _aY + _bY) + 3 * _t * (_aY - _fromY) + _fromY;
 	}

--- a/haxepunk/tweens/motion/LinearMotion.hx
+++ b/haxepunk/tweens/motion/LinearMotion.hx
@@ -65,14 +65,14 @@ class LinearMotion extends Motion
 
 	/** @private Updates the Tween. */
 	@:dox(hide)
-	override public function update()
+	override public function update(elapsed:Float)
 	{
-		super.update();
+		super.update(elapsed);
 		x = _fromX + _moveX * _t;
 		y = _fromY + _moveY * _t;
 		if (x == _fromX + _moveX && y == _fromY + _moveY && active)
 		{
-			super.update();
+			super.update(elapsed);
 			finish();
 		}
 	}

--- a/haxepunk/tweens/motion/LinearPath.hx
+++ b/haxepunk/tweens/motion/LinearPath.hx
@@ -92,9 +92,9 @@ class LinearPath extends Motion
 
 	/** @private Updates the Tween. */
 	@:dox(hide)
-	override public function update()
+	override public function update(elapsed:Float)
 	{
-		super.update();
+		super.update(elapsed);
 		if (_index < _points.length - 1)
 		{
 			while (_t > _pointT[_index + 1]) _index++;

--- a/haxepunk/tweens/motion/QuadMotion.hx
+++ b/haxepunk/tweens/motion/QuadMotion.hx
@@ -75,9 +75,9 @@ class QuadMotion extends Motion
 
 	/** @private Updates the Tween. */
 	@:dox(hide)
-	override public function update()
+	override public function update(elapsed:Float)
 	{
-		super.update();
+		super.update(elapsed);
 		x = _fromX * (1 - _t) * (1 - _t) + _controlX * 2 * (1 - _t) * _t + _toX * _t * _t;
 		y = _fromY * (1 - _t) * (1 - _t) + _controlY * 2 * (1 - _t) * _t + _toY * _t * _t;
 	}

--- a/haxepunk/tweens/motion/QuadPath.hx
+++ b/haxepunk/tweens/motion/QuadPath.hx
@@ -91,9 +91,9 @@ class QuadPath extends Motion
 
 	/** @private Updates the Tween. */
 	@:dox(hide)
-	override public function update()
+	override public function update(elapsed:Float)
 	{
-		super.update();
+		super.update(elapsed);
 		if (_index < _curve.length - 1)
 		{
 			while (_t > _curveT[_index + 1]) _index++;

--- a/haxepunk/tweens/sound/Fader.hx
+++ b/haxepunk/tweens/sound/Fader.hx
@@ -14,11 +14,11 @@ class Fader extends Tween
 	 * @param	complete	Optional completion callback.
 	 * @param	type		Tween type.
 	 */
-	public function new(?complete:Dynamic -> Void, ?type:TweenType) 
+	public function new(?complete:Dynamic -> Void, ?type:TweenType)
 	{
 		super(0, type, complete);
 	}
-	
+
 	/**
 	 * Fades FP.volume to the target volume.
 	 * @param	volume		The volume to fade to.
@@ -34,15 +34,15 @@ class Fader extends Tween
 		_ease = ease;
 		start();
 	}
-	
+
 	/** @private Updates the Tween. */
 	@:dox(hide)
-	override public function update() 
+	override public function update(elapsed:Float)
 	{
-		super.update();
+		super.update(elapsed);
 		HXP.volume = _start + _range * _t;
 	}
-	
+
 	// Fader information.
 	var _start:Float;
 	var _range:Float;

--- a/haxepunk/tweens/sound/SfxFader.hx
+++ b/haxepunk/tweens/sound/SfxFader.hx
@@ -60,9 +60,9 @@ class SfxFader extends Tween
 
 	/** @private Updates the Tween. */
 	@:dox(hide)
-	override public function update()
+	override public function update(elapsed:Float)
 	{
-		super.update();
+		super.update(elapsed);
 		if (_sfx != null) _sfx.volume = _start + _range * _t;
 		if (_crossSfx != null) _crossSfx.volume = _crossRange * _t;
 	}
@@ -83,7 +83,7 @@ class SfxFader extends Tween
 	 * The current Sfx this object is effecting.
 	 */
 	public var sfx(get, null):Sfx;
-	function get_sfx():Sfx return _sfx; 
+	function get_sfx():Sfx return _sfx;
 
 	// Fader information.
 	var _sfx:Sfx;

--- a/tests/src/haxepunk/TweenTest.hx
+++ b/tests/src/haxepunk/TweenTest.hx
@@ -80,7 +80,8 @@ class TweenTest
 		var tween = new Tween(10);
 		tween.start();
 		tween.update(11);
-		Assert.areEqual(1.1, tween.percent);
+		Assert.areEqual(1.0, tween.percent);
 		Assert.areEqual(1.0, tween.scale);
 	}
+
 }

--- a/tests/src/haxepunk/TweenTest.hx
+++ b/tests/src/haxepunk/TweenTest.hx
@@ -25,7 +25,7 @@ class TweenTest
 		var tween = new Tween(0);
 		tween.start();
 		Assert.isFalse(tween.active);
-		tween.update();
+		tween.update(0);
 		Assert.areEqual(0.0, tween.percent);
 	}
 
@@ -48,8 +48,7 @@ class TweenTest
 	public function testUpdateWithoutStart()
 	{
 		var tween = new Tween(10);
-		HXP.elapsed = 1;
-		tween.update();
+		tween.update(1);
 		Assert.areEqual(0.0, tween.percent);
 	}
 
@@ -57,11 +56,10 @@ class TweenTest
 	public function testUpdateWithStart()
 	{
 		var tween = new Tween(10);
-		HXP.elapsed = 1;
 		Assert.areEqual(0, tween.percent);
 		tween.start();
 		Assert.areEqual(0, tween.percent);
-		tween.update();
+		tween.update(1);
 		Assert.areEqual(0.1, tween.percent);
 	}
 
@@ -69,11 +67,10 @@ class TweenTest
 	public function testScale()
 	{
 		var tween = new Tween(10);
-		HXP.elapsed = 1;
 		Assert.areEqual(0, tween.scale);
 		tween.start();
 		Assert.areEqual(0, tween.scale);
-		tween.update();
+		tween.update(1);
 		Assert.areEqual(0.1, tween.scale);
 	}
 
@@ -81,9 +78,8 @@ class TweenTest
 	public function testUpdatePastTarget()
 	{
 		var tween = new Tween(10);
-		HXP.elapsed = 11;
 		tween.start();
-		tween.update();
+		tween.update(11);
 		Assert.areEqual(1.1, tween.percent);
 		Assert.areEqual(1.0, tween.scale);
 	}

--- a/tests/src/haxepunk/TweenerTest.hx
+++ b/tests/src/haxepunk/TweenerTest.hx
@@ -12,11 +12,68 @@ class TweenerTest
 	}
 
 	@Test
+	public function testHasTween()
+	{
+		var tween = new Tween(0);
+		Assert.isFalse(tweener.hasTween);
+		tweener.addTween(tween);
+		Assert.isTrue(tweener.hasTween);
+	}
+
+	@Test
 	public function testAddTwice()
 	{
 		var tween = new Tween(1);
 		tweener.addTween(tween);
 		Assert.throws(String, function() tweener.addTween(tween));
+	}
+
+	@Test
+	public function testCallback()
+	{
+		var called = 0;
+		var tween = new Tween(2, Persist, function(_) called += 1);
+		tweener.addTween(tween, true);
+		Assert.areEqual(0, called);
+		tweener.updateTweens(1);
+		Assert.areEqual(0, called);
+		tweener.updateTweens(1);
+		Assert.areEqual(1, called);
+		tweener.updateTweens(1);
+		Assert.areEqual(1, called);
+	}
+
+	@Test
+	public function testRemoveFromNonParent()
+	{
+		var tween = new Tween(1);
+		Assert.throws(String, function() tweener.removeTween(tween));
+	}
+
+	@Test
+	public function testRemovedIsInactive()
+	{
+		var tween = new Tween(1);
+		tweener.addTween(tween, true);
+		Assert.isTrue(tween.active);
+		tweener.removeTween(tween);
+		Assert.isFalse(tween.active);
+	}
+
+	@Test
+	public function testClearTweens()
+	{
+		var tweens = [new Tween(1), new Tween(3), new Tween(2)];
+		for (tween in tweens)
+		{
+			tweener.addTween(tween, true);
+			Assert.isTrue(tween.active);
+		}
+		tweener.clearTweens();
+		for (tween in tweens)
+		{
+			Assert.isFalse(tween.active);
+		}
 	}
 
 	var tweener:Tweener;

--- a/tests/src/haxepunk/tweens/misc/MultiVarTweenTest.hx
+++ b/tests/src/haxepunk/tweens/misc/MultiVarTweenTest.hx
@@ -1,0 +1,50 @@
+package haxepunk.tweens.misc;
+
+import massive.munit.Assert;
+
+class MultiVarTweenTest extends TestSuite
+{
+	@Test
+	public function testTweenNullProperties()
+	{
+		var tween = new MultiVarTween();
+		Assert.throws(String, function() tween.tween({}, null, 0));
+	}
+
+	@Test
+	public function testTweenNonNumeric()
+	{
+		var tween = new MultiVarTween();
+		Assert.throws(String, function() tween.tween({}, {foo:1, bar:"baz"}, 0));
+	}
+
+	@Test
+	public function testTweenNonExistantProperty()
+	{
+		var tween = new MultiVarTween();
+		Assert.throws(String, function() tween.tween({bar:0}, {foo:1}, 0));
+	}
+
+	@Test
+	public function testValidTween()
+	{
+		var tween = new MultiVarTween();
+		tween.tween({foo:0}, {foo:1}, 1);
+		Assert.isTrue(tween.active);
+	}
+
+	@Test
+	public function testTweenUpdate()
+	{
+		var tween = new MultiVarTween();
+		var obj = {foo:0, bar:0};
+		tween.tween(obj, {foo:2, bar:3}, 2);
+		tween.update(1);
+		Assert.areEqual(1, obj.foo);
+		Assert.areEqual(1.5, obj.bar);
+		tween.update(1);
+		Assert.areEqual(2, obj.foo);
+		Assert.areEqual(3, obj.bar);
+		Assert.isFalse(tween.active);
+	}
+}

--- a/tests/src/haxepunk/tweens/misc/VarTweenTest.hx
+++ b/tests/src/haxepunk/tweens/misc/VarTweenTest.hx
@@ -1,0 +1,44 @@
+package haxepunk.tweens.misc;
+
+import massive.munit.Assert;
+
+class VarTweenTest extends TestSuite
+{
+
+	@Test
+	public function testTweenNullObject()
+	{
+		var tween = new VarTween();
+		Assert.throws(String, function() tween.tween(null, "foo", 0, 0));
+	}
+
+	@Test
+	public function testTweenNonNumericProperty()
+	{
+		var tween = new VarTween();
+		var foo = { bar: "string" };
+		Assert.throws(String, function() tween.tween(foo, "bar", 0, 0));
+	}
+
+	@Test
+	public function testTweenDurationIsZero()
+	{
+		var tween = new VarTween();
+		Assert.isFalse(tween.active);
+		var foo = { bar: 0 };
+		tween.tween(foo, "bar", 0, 0);
+		Assert.isFalse(tween.active);
+	}
+
+	@Test
+	public function testTweenUpdate()
+	{
+		var tween = new VarTween();
+		var foo = { bar: 0 };
+		tween.tween(foo, "bar", 1, 2);
+		Assert.isTrue(tween.active);
+		tween.update(1);
+		Assert.areEqual(0.5, foo.bar);
+	}
+
+}

--- a/tests/src/haxepunk/tweens/misc/VarTweenTest.hx
+++ b/tests/src/haxepunk/tweens/misc/VarTweenTest.hx
@@ -4,7 +4,6 @@ import massive.munit.Assert;
 
 class VarTweenTest extends TestSuite
 {
-
 	@Test
 	public function testTweenNullObject()
 	{
@@ -25,8 +24,7 @@ class VarTweenTest extends TestSuite
 	{
 		var tween = new VarTween();
 		Assert.isFalse(tween.active);
-		var foo = { bar: 0 };
-		tween.tween(foo, "bar", 0, 0);
+		tween.tween({ foo: 0 }, "foo", 0, 0);
 		Assert.isFalse(tween.active);
 	}
 
@@ -40,5 +38,4 @@ class VarTweenTest extends TestSuite
 		tween.update(1);
 		Assert.areEqual(0.5, foo.bar);
 	}
-
 }


### PR DESCRIPTION
I added unit tests for the var Tweens and Tweener class. The update function now explicitly takes an elapsed parameter instead of using it from HXP.elapsed. I felt this code was buried and it makes the unit tests cleaner.

This also found an issue with Tweener.clearTweens that is resolved.