### PR TITLE
Fixed an issue on overwriteBitmapCache

### DIFF
--- a/haxepunk/HXP.hx
+++ b/haxepunk/HXP.hx
@@ -378,8 +378,9 @@ class HXP
 	 */
 	public static function overwriteBitmapCache(name:String, data:BitmapData):Bool
 	{
+		var removed = removeBitmap(name);
 		_bitmap.set(name, data);
-		return removeBitmap(name);
+		return removed;
 	}
 
 	/**


### PR DESCRIPTION
The previous code would write to the cache and delete it instantly after, also removeBitmap would always return true as bitmapAdded had just been added.