### PR TITLE
Fixing blend mode default and null texture check

### DIFF
--- a/haxepunk/Graphic.hx
+++ b/haxepunk/Graphic.hx
@@ -114,7 +114,7 @@ class Graphic
 	 * Optional blend mode to use when drawing this image.
 	 * Use constants from the haxepunk.utils.BlendMode class.
 	 */
-	public var blend:BlendMode;
+	public var blend:BlendMode = BlendMode.Alpha;
 
 	/**
 	 * Optional rectangle to clip the portion of this graphic that will be

--- a/haxepunk/graphics/ColoredRect.hx
+++ b/haxepunk/graphics/ColoredRect.hx
@@ -26,7 +26,7 @@ class ColoredRect extends Graphic
 	override public function render(point:Point, camera:Camera)
 	{
 		var batch = AtlasData._scene.renderer.batch,
-			command = batch.getDrawCommand(Texture.nullTexture, shader,
+			command = batch.getDrawCommand(null, shader,
 				false, blend, screenClipRect(camera, point.x, point.y));
 
 		var fsx = camera.fullScaleX,

--- a/haxepunk/graphics/ColoredRect.hx
+++ b/haxepunk/graphics/ColoredRect.hx
@@ -26,7 +26,7 @@ class ColoredRect extends Graphic
 	override public function render(point:Point, camera:Camera)
 	{
 		var batch = AtlasData._scene.renderer.batch,
-			command = batch.getDrawCommand(null, shader,
+			command = batch.getDrawCommand(Texture.nullTexture, shader,
 				false, blend, screenClipRect(camera, point.x, point.y));
 
 		var fsx = camera.fullScaleX,

--- a/haxepunk/graphics/hardware/DrawCommand.hx
+++ b/haxepunk/graphics/hardware/DrawCommand.hx
@@ -117,7 +117,7 @@ class DrawCommand
 			command = new DrawCommand();
 		}
 		command.shader = shader;
-		command.texture = texture == null ? Texture.nullTexture : texture;
+		command.texture = texture;
 		command.smooth = smooth;
 		command.blend = blend;
 		command.clipRect = clipRect;

--- a/haxepunk/graphics/hardware/DrawCommandBatch.hx
+++ b/haxepunk/graphics/hardware/DrawCommandBatch.hx
@@ -29,7 +29,11 @@ class DrawCommandBatch
 
 	public function getDrawCommand(texture:Texture, shader:Shader, smooth:Bool, blend:BlendMode, clipRect:Rectangle, x1:Float=0, y1:Float=0, x2:Float=0, y2:Float=0, x3:Float=0, y3:Float=0)
 	{
-		if (texture == null) texture = Texture.nullTexture;
+		if (texture == null)
+		{
+			texture = Texture.nullTexture;
+		}
+
 		if (last != null && last.match(texture, shader, smooth, blend, clipRect))
 		{
 			// we can reuse the most recent draw call

--- a/haxepunk/graphics/hardware/DrawCommandBatch.hx
+++ b/haxepunk/graphics/hardware/DrawCommandBatch.hx
@@ -29,6 +29,7 @@ class DrawCommandBatch
 
 	public function getDrawCommand(texture:Texture, shader:Shader, smooth:Bool, blend:BlendMode, clipRect:Rectangle, x1:Float=0, y1:Float=0, x2:Float=0, y2:Float=0, x3:Float=0, y3:Float=0)
 	{
+		if (texture == null) texture = Texture.nullTexture;
 		if (last != null && last.match(texture, shader, smooth, blend, clipRect))
 		{
 			// we can reuse the most recent draw call

--- a/haxepunk/graphics/hardware/DrawCommandBatch.hx
+++ b/haxepunk/graphics/hardware/DrawCommandBatch.hx
@@ -29,7 +29,7 @@ class DrawCommandBatch
 
 	public function getDrawCommand(texture:Texture, shader:Shader, smooth:Bool, blend:BlendMode, clipRect:Rectangle, x1:Float=0, y1:Float=0, x2:Float=0, y2:Float=0, x3:Float=0, y3:Float=0)
 	{
-		if (last != null && texture != null && last.match(texture, shader, smooth, blend, clipRect))
+		if (last != null && last.match(texture, shader, smooth, blend, clipRect))
 		{
 			// we can reuse the most recent draw call
 			return last;

--- a/haxepunk/graphics/hardware/HardwareRenderer.hx
+++ b/haxepunk/graphics/hardware/HardwareRenderer.hx
@@ -68,8 +68,7 @@ class HardwareRenderer
 			case BlendMode.Subtract:
 				GL.blendEquationSeparate(GL.FUNC_REVERSE_SUBTRACT, GL.FUNC_ADD);
 				GL.blendFuncSeparate(GL.ONE, GL.ONE, GL.ZERO, GL.ONE);
-			default:
-				// BlendMode.Alpha
+			case BlendMode.Alpha:
 				GL.blendEquation(GL.FUNC_ADD);
 				GL.blendFunc(GL.ONE, GL.ONE_MINUS_SRC_ALPHA);
 		}

--- a/haxepunk/utils/DrawContext.hx
+++ b/haxepunk/utils/DrawContext.hx
@@ -6,7 +6,6 @@ import haxepunk.HXP;
 import haxepunk.Graphic;
 import haxepunk.graphics.text.Text;
 import haxepunk.graphics.hardware.DrawCommand;
-import haxepunk.graphics.hardware.Texture;
 import haxepunk.graphics.shader.ColorShader;
 import haxepunk.graphics.shader.Shader;
 import haxepunk.math.Vector2;
@@ -389,7 +388,7 @@ class DrawContext
 	{
 		if (shader == null) shader = new ColorShader();
 		var scene = (this.scene == null) ? (HXP.renderingScene == null ? HXP.scene : HXP.renderingScene) : this.scene;
-		command = scene.renderer.batch.getDrawCommand(Texture.nullTexture, shader, smooth, blend, null);
+		command = scene.renderer.batch.getDrawCommand(null, shader, smooth, blend, null);
 	}
 
 	inline function drawTriangle(v1:Vector2, v2:Vector2, v3:Vector2):Void

--- a/haxepunk/utils/DrawContext.hx
+++ b/haxepunk/utils/DrawContext.hx
@@ -6,6 +6,7 @@ import haxepunk.HXP;
 import haxepunk.Graphic;
 import haxepunk.graphics.text.Text;
 import haxepunk.graphics.hardware.DrawCommand;
+import haxepunk.graphics.hardware.Texture;
 import haxepunk.graphics.shader.ColorShader;
 import haxepunk.graphics.shader.Shader;
 import haxepunk.math.Vector2;
@@ -22,7 +23,7 @@ class DrawContext
 	 * The blending mode used by Draw functions. This will not
 	 * apply to Draw.line(), but will apply to Draw.linePlus().
 	 */
-	public var blend:BlendMode;
+	public var blend:BlendMode = BlendMode.Alpha;
 
 	/**
 	 * The shader used by Draw functions. This will default to
@@ -388,7 +389,7 @@ class DrawContext
 	{
 		if (shader == null) shader = new ColorShader();
 		var scene = (this.scene == null) ? (HXP.renderingScene == null ? HXP.scene : HXP.renderingScene) : this.scene;
-		command = scene.renderer.batch.getDrawCommand(null, shader, smooth, blend, null);
+		command = scene.renderer.batch.getDrawCommand(Texture.nullTexture, shader, smooth, blend, null);
 	}
 
 	inline function drawTriangle(v1:Vector2, v2:Vector2, v3:Vector2):Void


### PR DESCRIPTION
BlendMode was defaulting to Add instead of Alpha with the change to an abstract class. Also, when Texture was null it would keep creating a new DrawCommand instance so I'm using `Texture.nullTexture`.