### PR TITLE
Added non-convex polygon hitbox

### DIFF
--- a/haxepunk/masks/Polygon.hx
+++ b/haxepunk/masks/Polygon.hx
@@ -39,11 +39,11 @@ class Polygon extends Hitbox
 	 * @param	points		An array of coordinates that define the polygon (must have at least 3 and defined counter-clockwise).
 	 * @param	origin	 	Pivot point for rotations.
 	 */
-	static public function fromPoints(points:Array<Vector2>, ?origin:Point) : Masklist
+	public static function fromPoints(points:Array<Vector2>, ?origin:Point) : Masklist
 	{
 		var cp = MakeConvex.run(points);
 		var list = new Masklist();
-		for(p in cp)
+		for (p in cp)
 			list.add(new Polygon(p, origin));
 		return list;
 	}

--- a/haxepunk/masks/Polygon.hx
+++ b/haxepunk/masks/Polygon.hx
@@ -9,11 +9,12 @@ import haxepunk.masks.Hitbox;
 import haxepunk.math.Projection;
 import haxepunk.math.Vector2;
 import haxepunk.math.MathUtil;
+import haxepunk.math.MakeConvex;
 import flash.geom.Point;
 
 
 /**
- * Uses polygonal structure to check for collisions.
+ * Uses a convex polygonal structure to check for collisions.
  */
 class Polygon extends Hitbox
 {
@@ -31,13 +32,28 @@ class Polygon extends Hitbox
 	public var maxX(default, null):Int = 0;
 	/** Bottom y bounding box position. */
 	public var maxY(default, null):Int = 0;
-
+	
 	/**
-	 * Constructor.
-	 * @param	points		An array of coordinates that define the polygon (must have at least 3).
+	 * Creates a list of convex polygonal masks based on an array of vertices defined counter-clockwise.
+	 * The polygon must be simple (non-self-intersecting), but not necessarily convex.
+	 * @param	points		An array of coordinates that define the polygon (must have at least 3 and defined counter-clockwise).
 	 * @param	origin	 	Pivot point for rotations.
 	 */
-	public function new(points:Array<Vector2>, ?origin:Point)
+	static public function fromPoints(points:Array<Vector2>, ?origin:Point) : Masklist
+	{
+		var cp = MakeConvex.run(points);
+		var list = new Masklist();
+		for(p in cp)
+			list.add(new Polygon(p, origin));
+		return list;
+	}
+	
+	/**
+	 * Constructor. The passed polygon must be convex.
+	 * @param	points		An array of coordinates that define the polygon (must have at least 3 and be convex).
+	 * @param	origin	 	Pivot point for rotations.
+	 */
+	private function new(points:Array<Vector2>, ?origin:Point)
 	{
 		super();
 		if (points.length < 3) throw "The polygon needs at least 3 sides.";

--- a/haxepunk/math/MakeConvex.hx
+++ b/haxepunk/math/MakeConvex.hx
@@ -1,0 +1,153 @@
+package haxepunk.math;
+
+import haxepunk.math.Vector2;
+
+// A polygon is a path along points CCW
+typedef Polygon = Array<Point>;
+
+/**
+ * MakeConvex class
+ * 
+ * Decomposes simple polygons into convex polygons in under-quadratic time.
+ * @author Matrefeytontias
+ */
+class MakeConvex
+{
+	// Find all invalid vertices, that is, vertices that form an invalid angle (> 180°)
+	static private function findInvalid(p:Polygon) : Array<Int>
+	{
+		var invalidVertices = new Array<Int>();
+		var np = p.length;
+		for(currentVIndex in 0 ... np)
+		{
+			var currentV = p[currentVIndex];
+			var nextV = p[(currentVIndex + 1) % np];
+			var nextNextV = p[(currentVIndex + 2) % np];
+			var currentEdge = nextV - currentV;
+			var nextEdge = nextNextV - nextV;
+			if(currentEdge.orthoR().dot(nextEdge) < 0)
+				invalidVertices.push((currentVIndex + 1) % np);
+		}
+		return invalidVertices;
+	}
+	
+	/**
+	 * Decomposes a counter-clockwise simple polygon into convex polygons.
+	 */
+	static public function run(polygon:Polygon) : Array<Polygon>
+	{
+		var p = polygon.copy();
+		var r = new Array<Polygon>();
+		var invalidVertices = findInvalid(p);
+		var np = p.length;
+		
+		var n:Int = invalidVertices.length;
+		while((n = invalidVertices.length) > 0)
+		{
+			// Find the starting vertex ; it's any invalid vertex that has a valid vertex after it
+			// we know this exists because a polygon must have at least one valid vertex
+			var startIndex:Int = 0;
+			for(i in 0 ... n)
+			{
+				if(n == 1 || (invalidVertices[i] + 1) % np != invalidVertices[(i + 1) % n])
+				{
+					startIndex = invalidVertices[i];
+					break;
+				}
+			}
+			
+			// After that, find the furthest valid point along the polygon that still forms a convex
+			// polygon when linked to the starting vertex, or the first invalid vertex.
+			// This is because by definition, the two edges that an invalid vertex is a part of cannot
+			// belong to the same one polygon.
+			var startVertex = p[startIndex];
+			var firstEdge = p[(startIndex + 1) % np] - startVertex;
+			var found = false, target:Int = 0;
+			for(i in 2 ... np)
+			{
+				var curIndex = (startIndex + i) % np,
+					curVertex = p[curIndex];
+				
+				// This vertex is invalid
+				if(invalidVertices.indexOf(curIndex) > -1)
+				{
+					found = true;
+					target = curIndex;
+				}
+				// This vertex, if added, would turn the polygon from convex to concave.
+				// Thus, the correct vertex is the previous one
+				else if((startVertex - curVertex).orthoR().dot(firstEdge) < 0)
+				{
+					found = true;
+					target = (startIndex + i - 1) % np;
+				}
+				
+				if(found)
+				{
+					// Extract vertices startIndex to "target" ; they make up a convex polygon
+					var newPoly = new Polygon(),
+						k = startIndex;
+					while(true)
+					{
+						newPoly.push(p[k]);
+						if(k == target)
+							break;
+						k = (k + 1) % np;
+					}
+					r.push(newPoly);
+					// Then, discard the vertices that were added to the resulting array, except the start and end
+					p = p.filter(function(x) return newPoly.indexOf(x) == -1 || x == startVertex || x == p[target]);
+					np = p.length;
+					// Rearrange the indices in invalidVertices as well, since the contents of p will change
+					invalidVertices = findInvalid(p);
+					if(invalidVertices.length == 0)
+						r.push(p);
+					break;
+				}
+			}
+		}
+		
+		return r.length == 0 ? [polygon] : r;
+	}
+}
+
+// Convenience type with overloaded operations
+// R is for Reentrant
+@:forward
+abstract Point(Vector2) from Vector2 to Vector2
+{
+	public function new(x:Float = 0., y:Float = 0.)
+	{
+		this = new Vector2(x, y);
+	}
+	
+	@:from static public function fromStruct(v:{x:Float, y:Float}) : Point
+	{
+		return new Point(v.x, v.y);
+	}
+	
+	@:op(A + B) public function addR(b:Point) : Point
+	{
+		return new Point(this.x + b.x, this.y + b.y);
+	}
+	
+	@:op(A - B) public function subR(b:Point) : Point
+	{
+		return addR(b.negR());
+	}
+	
+	@:op(-A) public function negR() : Point
+	{
+		return new Point(-this.x, -this.y);
+	}
+	
+	@:op(A * B) public function dot(b:Point) : Float
+	{
+		return this.x * b.x + this.y * b.y;
+	}
+	
+	public function orthoR() : Point
+	{
+		return new Point(this.y, -this.x);
+	}
+}

--- a/haxepunk/math/MakeConvex.hx
+++ b/haxepunk/math/MakeConvex.hx
@@ -1,7 +1,5 @@
 package haxepunk.math;
 
-import haxepunk.math.Vector2;
-
 // A polygon is a path along points CCW
 typedef Polygon = Array<Point>;
 
@@ -14,18 +12,18 @@ typedef Polygon = Array<Point>;
 class MakeConvex
 {
 	// Find all invalid vertices, that is, vertices that form an invalid angle (> 180°)
-	static private function findInvalid(p:Polygon) : Array<Int>
+	private static function findInvalid(p:Polygon) : Array<Int>
 	{
 		var invalidVertices = new Array<Int>();
 		var np = p.length;
-		for(currentVIndex in 0 ... np)
+		for (currentVIndex in 0 ... np)
 		{
 			var currentV = p[currentVIndex];
 			var nextV = p[(currentVIndex + 1) % np];
 			var nextNextV = p[(currentVIndex + 2) % np];
 			var currentEdge = nextV - currentV;
 			var nextEdge = nextNextV - nextV;
-			if(currentEdge.orthoR().dot(nextEdge) < 0)
+			if (currentEdge.orthoR().dot(nextEdge) < 0)
 				invalidVertices.push((currentVIndex + 1) % np);
 		}
 		return invalidVertices;
@@ -34,7 +32,7 @@ class MakeConvex
 	/**
 	 * Decomposes a counter-clockwise simple polygon into convex polygons.
 	 */
-	static public function run(polygon:Polygon) : Array<Polygon>
+	public static function run(polygon:Polygon) : Array<Polygon>
 	{
 		var p = polygon.copy();
 		var r = new Array<Polygon>();
@@ -42,14 +40,14 @@ class MakeConvex
 		var np = p.length;
 		
 		var n:Int = invalidVertices.length;
-		while((n = invalidVertices.length) > 0)
+		while ((n = invalidVertices.length) > 0)
 		{
 			// Find the starting vertex ; it's any invalid vertex that has a valid vertex after it
 			// we know this exists because a polygon must have at least one valid vertex
 			var startIndex:Int = 0;
-			for(i in 0 ... n)
+			for (i in 0 ... n)
 			{
-				if(n == 1 || (invalidVertices[i] + 1) % np != invalidVertices[(i + 1) % n])
+				if (n == 1 || (invalidVertices[i] + 1) % np != invalidVertices[(i + 1) % n])
 				{
 					startIndex = invalidVertices[i];
 					break;
@@ -63,34 +61,34 @@ class MakeConvex
 			var startVertex = p[startIndex];
 			var firstEdge = p[(startIndex + 1) % np] - startVertex;
 			var found = false, target:Int = 0;
-			for(i in 2 ... np)
+			for (i in 2 ... np)
 			{
 				var curIndex = (startIndex + i) % np,
 					curVertex = p[curIndex];
 				
 				// This vertex is invalid
-				if(invalidVertices.indexOf(curIndex) > -1)
+				if (invalidVertices.indexOf(curIndex) > -1)
 				{
 					found = true;
 					target = curIndex;
 				}
 				// This vertex, if added, would turn the polygon from convex to concave.
 				// Thus, the correct vertex is the previous one
-				else if((startVertex - curVertex).orthoR().dot(firstEdge) < 0)
+				else if ((startVertex - curVertex).orthoR().dot(firstEdge) < 0)
 				{
 					found = true;
 					target = (startIndex + i - 1) % np;
 				}
 				
-				if(found)
+				if (found)
 				{
 					// Extract vertices startIndex to "target" ; they make up a convex polygon
 					var newPoly = new Polygon(),
 						k = startIndex;
-					while(true)
+					while (true)
 					{
 						newPoly.push(p[k]);
-						if(k == target)
+						if (k == target)
 							break;
 						k = (k + 1) % np;
 					}
@@ -100,7 +98,7 @@ class MakeConvex
 					np = p.length;
 					// Rearrange the indices in invalidVertices as well, since the contents of p will change
 					invalidVertices = findInvalid(p);
-					if(invalidVertices.length == 0)
+					if (invalidVertices.length == 0)
 						r.push(p);
 					break;
 				}
@@ -121,7 +119,7 @@ abstract Point(Vector2) from Vector2 to Vector2
 		this = new Vector2(x, y);
 	}
 	
-	@:from static public function fromStruct(v:{x:Float, y:Float}) : Point
+	@:from public static function fromStruct(v:{x:Float, y:Float}) : Point
 	{
 		return new Point(v.x, v.y);
 	}


### PR DESCRIPTION
This adds the MakeConvex utils class, and a new `haxepunk.masks.Polygon.fromPoints` function that creates an array of convex polygonal hitboxes, thus effectively extending the Polygon hitboxes to non-convex polygons.