### PR TITLE
Move OpenGL classes to package

### DIFF
--- a/haxepunk/graphics/hardware/FrameBuffer.hx
+++ b/haxepunk/graphics/hardware/FrameBuffer.hx
@@ -1,8 +1,9 @@
 package haxepunk.graphics.hardware;
 
-import flash.gl.GL;
-import flash.gl.GLFramebuffer;
-import flash.gl.GLTexture;
+import haxepunk.graphics.hardware.opengl.GL;
+import haxepunk.graphics.hardware.opengl.GLFramebuffer;
+import haxepunk.graphics.hardware.opengl.GLTexture;
+import haxepunk.graphics.hardware.opengl.GLUtils;
 
 @:dox(hide)
 class FrameBuffer

--- a/haxepunk/graphics/hardware/HardwareRenderer.hx
+++ b/haxepunk/graphics/hardware/HardwareRenderer.hx
@@ -3,8 +3,9 @@ package haxepunk.graphics.hardware;
 import haxe.PosInfos;
 import flash.geom.Rectangle;
 import flash.geom.Point;
-import flash.gl.GL;
-import flash.gl.GLFramebuffer;
+import haxepunk.graphics.hardware.opengl.GL;
+import haxepunk.graphics.hardware.opengl.GLFramebuffer;
+import haxepunk.graphics.hardware.opengl.GLUtils;
 import haxepunk.HXP;
 import haxepunk.graphics.shader.SceneShader;
 import haxepunk.utils.BlendMode;
@@ -190,6 +191,7 @@ class HardwareRenderer
 			destroy();
 			init();
 		}
+
 
 		var postProcess:Array<SceneShader> = scene.shaders;
 		if (postProcess != null && postProcess.length > 0)

--- a/haxepunk/graphics/hardware/RenderBuffer.hx
+++ b/haxepunk/graphics/hardware/RenderBuffer.hx
@@ -3,8 +3,8 @@ package haxepunk.graphics.hardware;
 #if js
 import js.html.Int32Array;
 #end
-import flash.gl.GL;
-import flash.gl.GLBuffer;
+import haxepunk.graphics.hardware.opengl.GL;
+import haxepunk.graphics.hardware.opengl.GLBuffer;
 
 class RenderBuffer
 {

--- a/haxepunk/graphics/hardware/opengl/GL.hx
+++ b/haxepunk/graphics/hardware/opengl/GL.hx
@@ -1,0 +1,7 @@
+package haxepunk.graphics.hardware.opengl;
+
+#if lime
+typedef GL = lime.graphics.opengl.GL;
+#else
+typedef GL = flash.gl.GL;
+#end

--- a/haxepunk/graphics/hardware/opengl/GLBuffer.hx
+++ b/haxepunk/graphics/hardware/opengl/GLBuffer.hx
@@ -1,0 +1,7 @@
+package haxepunk.graphics.hardware.opengl;
+
+#if lime
+typedef GLBuffer = lime.graphics.opengl.GLBuffer;
+#else
+typedef GLBuffer = flash.gl.GLBuffer;
+#end

--- a/haxepunk/graphics/hardware/opengl/GLFramebuffer.hx
+++ b/haxepunk/graphics/hardware/opengl/GLFramebuffer.hx
@@ -1,0 +1,7 @@
+package haxepunk.graphics.hardware.opengl;
+
+#if lime
+typedef GLFramebuffer = lime.graphics.opengl.GLFramebuffer;
+#else
+typedef GLFramebuffer = flash.gl.GLFramebuffer;
+#end

--- a/haxepunk/graphics/hardware/opengl/GLProgram.hx
+++ b/haxepunk/graphics/hardware/opengl/GLProgram.hx
@@ -1,0 +1,7 @@
+package haxepunk.graphics.hardware.opengl;
+
+#if lime
+typedef GLProgram = lime.graphics.opengl.GLProgram;
+#else
+typedef GLProgram = flash.gl.GLProgram;
+#end

--- a/haxepunk/graphics/hardware/opengl/GLShader.hx
+++ b/haxepunk/graphics/hardware/opengl/GLShader.hx
@@ -1,0 +1,7 @@
+package haxepunk.graphics.hardware.opengl;
+
+#if lime
+typedef GLShader = lime.graphics.opengl.GLShader;
+#else
+typedef GLShader = flash.gl.GLShader;
+#end

--- a/haxepunk/graphics/hardware/opengl/GLTexture.hx
+++ b/haxepunk/graphics/hardware/opengl/GLTexture.hx
@@ -1,0 +1,7 @@
+package haxepunk.graphics.hardware.opengl;
+
+#if lime
+typedef GLTexture = lime.graphics.opengl.GLTexture;
+#else
+typedef GLTexture = flash.gl.GLTexture;
+#end

--- a/haxepunk/graphics/hardware/opengl/GLUniformLocation.hx
+++ b/haxepunk/graphics/hardware/opengl/GLUniformLocation.hx
@@ -1,0 +1,7 @@
+package haxepunk.graphics.hardware.opengl;
+
+#if lime
+typedef GLUniformLocation = lime.graphics.opengl.GLUniformLocation;
+#else
+typedef GLUniformLocation = flash.gl.GLUniformLocation;
+#end

--- a/haxepunk/graphics/hardware/opengl/GLUtils.hx
+++ b/haxepunk/graphics/hardware/opengl/GLUtils.hx
@@ -1,6 +1,6 @@
-package haxepunk.graphics.hardware;
+package haxepunk.graphics.hardware.opengl;
 
-import flash.gl.GL;
+import haxepunk.graphics.hardware.opengl.GL;
 import haxepunk.HXP;
 
 @:dox(hide)

--- a/haxepunk/graphics/shader/SceneShader.hx
+++ b/haxepunk/graphics/shader/SceneShader.hx
@@ -1,11 +1,11 @@
 package haxepunk.graphics.shader;
 
 import flash.Assets;
-import flash.gl.GL;
-import flash.gl.GLBuffer;
-import flash.gl.GLUniformLocation;
+import haxepunk.graphics.hardware.opengl.GL;
+import haxepunk.graphics.hardware.opengl.GLBuffer;
+import haxepunk.graphics.hardware.opengl.GLUniformLocation;
+import haxepunk.graphics.hardware.opengl.GLUtils;
 import haxepunk.graphics.hardware.Float32Array;
-import haxepunk.graphics.hardware.GLUtils;
 
 /**
  * Used to create a custom shader.

--- a/haxepunk/graphics/shader/Shader.hx
+++ b/haxepunk/graphics/shader/Shader.hx
@@ -1,9 +1,9 @@
 package haxepunk.graphics.shader;
 
-import flash.gl.GL;
-import flash.gl.GLProgram;
-import flash.gl.GLShader;
-import haxepunk.graphics.hardware.GLUtils;
+import haxepunk.graphics.hardware.opengl.GL;
+import haxepunk.graphics.hardware.opengl.GLProgram;
+import haxepunk.graphics.hardware.opengl.GLShader;
+import haxepunk.graphics.hardware.opengl.GLUtils;
 import haxepunk.graphics.hardware.DrawCommand;
 import haxepunk.graphics.hardware.Float32Array;
 import haxepunk.graphics.hardware.RenderBuffer;


### PR DESCRIPTION
- Fixes deprecation of `flash.gl` package in OpenFL 6.
- Opens up possibility of supporting other backends by hiding OpenGL imports.
- Moves GLUtils from `haxepunk.graphics.hardware` package.