### PR TITLE
BunnyMark OverlayText Fix

### DIFF
--- a/examples/HXPBunnies/src/scenes/GameScene.hx
+++ b/examples/HXPBunnies/src/scenes/GameScene.hx
@@ -58,19 +58,18 @@ class GameScene extends Scene
 		bunny = new Entity();
 		bunnyList = new Graphiclist([]);
 		bunny.graphic = bunnyList;
+		add(bunny);
 
 		// and some big pirate
 		pirate = new Image(atlas.getRegion("pirate.png"));
-		addGraphic(pirate, -1);// displayed in front of bunnies
+		addGraphic(pirate);
 
 		overlayText = new Text("numBunnies = " + numBunnies, 0, 0, 0, 0, { color:0x000000, size:30 } );
 		overlayText.resizable = true;
 		var overlay:Entity = new Entity(0, HXP.screen.height - 40, overlayText);
-		overlay.layer = -1000; // displayed in the very front
 		add(overlay);
 
 		addBunnies(numBunnies);
-		add(bunny);
 	}
 
 	function addBunnies(numToAdd:Int):Void

--- a/examples/HXPBunnies/src/scenes/GameScene.hx
+++ b/examples/HXPBunnies/src/scenes/GameScene.hx
@@ -47,7 +47,7 @@ class GameScene extends Scene
 		atlas = TextureAtlas.loadTexturePacker("atlas/assets.xml");
 	}
 
-	public override function begin()
+	override public function begin()
 	{
 		// background
 		backdrop = new Backdrop(atlas.getRegion("grass.png"), true, true);
@@ -94,7 +94,7 @@ class GameScene extends Scene
 		overlayText.text = "numBunnies = " + numBunnies;
 	}
 
-	public override function update()
+	override public function update()
 	{
 		var t = Lib.getTimer();
 		pirate.x = Std.int((HXP.width - pirate.width) * (0.5 + 0.5 * Math.sin(t / 3000)));

--- a/examples/HXPBunnies/src/scenes/GameScene.hx
+++ b/examples/HXPBunnies/src/scenes/GameScene.hx
@@ -61,6 +61,7 @@ class GameScene extends Scene
 
 		// and some big pirate
 		pirate = new Image(atlas.getRegion("pirate.png"));
+		addGraphic(pirate, -1);// displayed in front of bunnies
 
 		overlayText = new Text("numBunnies = " + numBunnies, 0, 0, 0, 0, { color:0x000000, size:30 } );
 		overlayText.resizable = true;

--- a/examples/HXPBunnies/src/scenes/GameScene.hx
+++ b/examples/HXPBunnies/src/scenes/GameScene.hx
@@ -58,17 +58,18 @@ class GameScene extends Scene
 		bunny = new Entity();
 		bunnyList = new Graphiclist([]);
 		bunny.graphic = bunnyList;
-		addBunnies(numBunnies);
-		add(bunny);
 
 		// and some big pirate
 		pirate = new Image(atlas.getRegion("pirate.png"));
-		addGraphic(pirate);
 
-		// overlayText = new Text("numBunnies = " + numBunnies, 0, 0, 0, 0, { color:0x000000, size:30 } );
-		// overlayText.resizable = true;
-		// var overlay:Entity = new Entity(0, HXP.screen.height - 40, overlayText);
-		// add(overlay);
+		overlayText = new Text("numBunnies = " + numBunnies, 0, 0, 0, 0, { color:0x000000, size:30 } );
+		overlayText.resizable = true;
+		var overlay:Entity = new Entity(0, HXP.screen.height - 40, overlayText);
+		overlay.layer = -1000; // displayed in the very front
+		add(overlay);
+
+		addBunnies(numBunnies);
+		add(bunny);
 	}
 
 	function addBunnies(numToAdd:Int):Void
@@ -89,8 +90,7 @@ class GameScene extends Scene
 		}
 
 		numBunnies = bunnies.length;
-		// overlayText.text = "numBunnies = " + numBunnies;
-		trace(numBunnies);
+		overlayText.text = "numBunnies = " + numBunnies;
 	}
 
 	public override function update()


### PR DESCRIPTION
**Problem:** The bunny add function was being called before the overlay text was initialized, therefore using a null value, causing an unexpected(and silent) crash.

**Solution:**
Simply moved the addBunnies function below the overlayText.

**Extra:**
- Made sure the pirate was a layer infront of bunnies
- Gave the overlay entity a layer of -1000 to prevent being covered.
- Removed unnecessary bunny count trace for console