### PR TITLE
Changing flash.geom.Point references to haxepunk.math.Vector2

### DIFF
--- a/haxepunk/Camera.hx
+++ b/haxepunk/Camera.hx
@@ -1,15 +1,27 @@
 package haxepunk;
 
-import flash.geom.Point;
-
 /**
  * @since 4.0.0
  */
-class Camera extends Point
+class Camera
 {
+	public var x:Float;
+	public var y:Float;
+
 	public var scale:Float = 1;
 	public var scaleX:Float = 1;
 	public var scaleY:Float = 1;
+
+	public function new(x:Float = 0, y:Float = 0)
+	{
+		setTo(x, y);
+	}
+
+	public inline function setTo(x:Float, y:Float)
+	{
+		this.x = x;
+		this.y = y;
+	}
 
 	/**
 	 * Whether this graphic will be snapped to the nearest whole number pixel

--- a/haxepunk/Entity.hx
+++ b/haxepunk/Entity.hx
@@ -1,6 +1,5 @@
 package haxepunk;
 
-import flash.geom.Point;
 import haxe.ds.Either.Left;
 import haxe.ds.Either.Right;
 import haxepunk.Signal.Signal0;
@@ -151,7 +150,6 @@ class Entity extends Tweener
 		_name = "";
 
 		HITBOX = new Mask();
-		_point = HXP.point;
 
 		layer = 0;
 
@@ -202,14 +200,14 @@ class Entity extends Tweener
 		{
 			if (graphic.relative)
 			{
-				_point.x = x;
-				_point.y = y;
+				HXP.point.x = x;
+				HXP.point.y = y;
 			}
 			else
 			{
-				_point.x = _point.y = 0;
+				HXP.point.x = HXP.point.y = 0;
 			}
-			graphic.doRender(_point, camera);
+			graphic.doRender(HXP.point, camera);
 		}
 	}
 
@@ -543,8 +541,8 @@ class Entity extends Tweener
 	inline function get_bottom():Float return top + height;
 
 	/**
-	 * The rendering layer of this Entity. Layers are drawn in descending order. 
-	 * Backgrounds will have large (positive) numbers, foregrounds will have 
+	 * The rendering layer of this Entity. Layers are drawn in descending order.
+	 * Backgrounds will have large (positive) numbers, foregrounds will have
 	 * small (negative) numbers.
 	 */
 	public var layer(get, set):Int;
@@ -841,13 +839,13 @@ class Entity extends Tweener
 	 */
 	public inline function moveTowards(x:Float, y:Float, amount:Float, ?solidType:SolidType, sweep:Bool = false)
 	{
-		_point.x = x - this.x;
-		_point.y = y - this.y;
-		if (_point.x * _point.x + _point.y * _point.y > amount * amount)
+		HXP.point.x = x - this.x;
+		HXP.point.y = y - this.y;
+		if (HXP.point.x * HXP.point.x + HXP.point.y * HXP.point.y > amount * amount)
 		{
-			_point.normalize(amount);
+			HXP.point.normalize(amount);
 		}
-		moveBy(_point.x, _point.y, solidType, sweep);
+		moveBy(HXP.point.x, HXP.point.y, solidType, sweep);
 	}
 
 	/**
@@ -944,9 +942,6 @@ class Entity extends Tweener
 	var _y:Float = 0;
 	var _moveX:Float = 0;
 	var _moveY:Float = 0;
-
-	// Rendering information.
-	var _point:Point;
 
 	static var _EMPTY:Entity = new Entity();
 }

--- a/haxepunk/Graphic.hx
+++ b/haxepunk/Graphic.hx
@@ -1,9 +1,9 @@
 package haxepunk;
 
+import flash.geom.Rectangle;
 import haxe.ds.Either;
 import haxepunk.utils.BlendMode;
-import flash.geom.Point;
-import flash.geom.Rectangle;
+import haxepunk.math.Vector2;
 import haxepunk.graphics.atlas.Atlas;
 import haxepunk.graphics.atlas.TileAtlas;
 import haxepunk.graphics.atlas.AtlasRegion;
@@ -262,7 +262,7 @@ class Graphic
 	 * @param  camera     The camera offset.
 	 */
 	@:dox(hide)
-	public function doRender(point:Point, camera:Camera)
+	public function doRender(point:Vector2, camera:Camera)
 	{
 		if (isPixelPerfect(camera)) pixelPerfectRender(point, camera);
 		else render(point, camera);
@@ -274,7 +274,7 @@ class Graphic
 	 * @param  camera     The camera offset.
 	 */
 	@:dox(hide)
-	public function render(point:Point, camera:Camera) {}
+	public function render(point:Vector2, camera:Camera) {}
 
 	/**
 	 * Renders the graphic, taking extra care to snap pixel locations and
@@ -284,7 +284,7 @@ class Graphic
 	 * @param  point      The position to draw the graphic.
 	 * @param  camera     The camera offset.
 	 */
-	public function pixelPerfectRender(point:Point, camera:Camera) render(point, camera);
+	public function pixelPerfectRender(point:Vector2, camera:Camera) render(point, camera);
 
 	/**
 	 * Pause updating this graphic.
@@ -307,6 +307,6 @@ class Graphic
 	var _class:String;
 	// Graphic information.
 	var _scroll:Bool = true;
-	var _point:Point = new Point();
+	var _point:Vector2 = new Vector2();
 	var _visible:Bool = true;
 }

--- a/haxepunk/HXP.hx
+++ b/haxepunk/HXP.hx
@@ -5,7 +5,6 @@ import flash.display.Sprite;
 import flash.display.Stage;
 import flash.display.StageDisplayState;
 import flash.geom.Matrix;
-import flash.geom.Point;
 import flash.geom.Rectangle;
 import flash.ui.Mouse;
 import haxepunk.Tween.TweenType;
@@ -14,6 +13,7 @@ import haxepunk.tweens.misc.Alarm;
 import haxepunk.tweens.misc.MultiVarTween;
 import haxepunk.utils.HaxelibInfo;
 import haxepunk.math.MathUtil;
+import haxepunk.math.Vector2;
 import haxepunk.math.Random;
 
 /**
@@ -550,9 +550,8 @@ class HXP
 	public static var engine:Engine;
 
 	// Global objects used for rendering, collision, etc.
-	@:dox(hide) public static var point:Point = new Point();
-	@:dox(hide) public static var point2:Point = new Point();
-	@:dox(hide) public static var zero:Point = new Point();
+	@:dox(hide) public static var point:Vector2 = new Vector2();
+	@:dox(hide) public static var point2:Vector2 = new Vector2();
 	@:dox(hide) public static var zeroCamera:Camera = new Camera();
 	@:dox(hide) public static var rect:Rectangle = new Rectangle();
 	@:dox(hide) public static var matrix:Matrix = new Matrix();

--- a/haxepunk/Scene.hx
+++ b/haxepunk/Scene.hx
@@ -1,7 +1,6 @@
 package haxepunk;
 
 import haxe.ds.IntMap;
-import flash.geom.Point;
 import haxepunk.Signal;
 import haxepunk.graphics.atlas.AtlasData;
 import haxepunk.graphics.shader.SceneShader;
@@ -10,6 +9,7 @@ import haxepunk.utils.BlendMode;
 import haxepunk.utils.Color;
 import haxepunk.utils.DrawContext;
 import haxepunk.math.MathUtil;
+import haxepunk.math.Vector2;
 
 /**
  * Updated by `Engine`, main game container that holds all currently active Entities.
@@ -564,7 +564,7 @@ class Scene extends Tweener
 	 * @param	p           If non-null, will have its x and y values set to the point of collision.
 	 * @return	The first Entity to collide, or null if none collide.
 	 */
-	public function collideLine(type:String, fromX:Int, fromY:Int, toX:Int, toY:Int, precision:Int = 1, p:Point = null):Entity
+	public function collideLine(type:String, fromX:Int, fromY:Int, toX:Int, toY:Int, precision:Int = 1, p:Vector2 = null):Entity
 	{
 		// If the distance is less than precision, do the short sweep.
 		if (precision < 1) precision = 1;

--- a/haxepunk/debug/Console.hx
+++ b/haxepunk/debug/Console.hx
@@ -1,7 +1,7 @@
 package haxepunk.debug;
 
 import haxepunk.utils.BlendMode;
-import flash.geom.Point;
+import haxepunk.math.Vector2;
 import flash.geom.Rectangle;
 import haxepunk.HXP;
 import haxepunk.cameras.UICamera;
@@ -75,7 +75,7 @@ class Console extends Scene
 	var _dc:Float = 0;
 	var _t:Float = 0;
 
-	var click:Point = new Point();
+	var click:Vector2 = new Vector2();
 	var selBox:Rectangle = new Rectangle();
 	var clickActive:Bool = false;
 	var dragging:Bool = false;

--- a/haxepunk/graphics/ColoredRect.hx
+++ b/haxepunk/graphics/ColoredRect.hx
@@ -1,10 +1,10 @@
 package haxepunk.graphics;
 
-import flash.geom.Point;
 import haxepunk.Graphic;
 import haxepunk.graphics.atlas.AtlasData;
 import haxepunk.graphics.shader.ColorShader;
 import haxepunk.utils.Color;
+import haxepunk.math.Vector2;
 
 class ColoredRect extends Graphic
 {
@@ -23,7 +23,7 @@ class ColoredRect extends Graphic
 
 	@:access(haxepunk.graphics.atlas.AtlasData)
 	@:access(haxepunk.graphics.hardware.SceneRenderer)
-	override public function render(point:Point, camera:Camera)
+	override public function render(point:Vector2, camera:Camera)
 	{
 		var command = AtlasData._batch.getDrawCommand(null, shader,
 				false, blend, screenClipRect(camera, point.x, point.y));

--- a/haxepunk/graphics/Graphiclist.hx
+++ b/haxepunk/graphics/Graphiclist.hx
@@ -1,9 +1,9 @@
 package haxepunk.graphics;
 
-import flash.geom.Point;
 import haxepunk.HXP;
 import haxepunk.Graphic;
 import haxepunk.utils.Color;
+import haxepunk.math.Vector2;
 
 /**
  * A Graphic that can contain multiple Graphics of one or various types.
@@ -70,7 +70,7 @@ class Graphiclist extends Graphic
 	}
 
 	/** @private Renders the Graphics in the list. */
-	override public function render(point:Point, camera:Camera)
+	override public function render(point:Vector2, camera:Camera)
 	{
 		var cx = camera.x,
 			cy = camera.y;

--- a/haxepunk/graphics/Image.hx
+++ b/haxepunk/graphics/Image.hx
@@ -1,6 +1,5 @@
 package haxepunk.graphics;
 
-import flash.geom.Point;
 import flash.geom.Rectangle;
 import haxepunk.Camera;
 import haxepunk.Graphic;
@@ -10,6 +9,7 @@ import haxepunk.graphics.atlas.IAtlasRegion;
 import haxepunk.graphics.hardware.Texture;
 import haxepunk.utils.Color;
 import haxepunk.math.MathUtil;
+import haxepunk.math.Vector2;
 
 /**
  * Performance-optimized non-animated image. Can be drawn to the screen with transformations.
@@ -88,7 +88,7 @@ class Image extends Graphic
 	}
 
 	@:dox(hide)
-	override public function render(point:Point, camera:Camera)
+	override public function render(point:Vector2, camera:Camera)
 	{
 		var sx = scale * scaleX,
 			sy = scale * scaleY,

--- a/haxepunk/graphics/NineSlice.hx
+++ b/haxepunk/graphics/NineSlice.hx
@@ -1,11 +1,11 @@
 package haxepunk.graphics;
 
-import flash.geom.Point;
 import flash.geom.Rectangle;
 import haxepunk.HXP;
 import haxepunk.Graphic;
 import haxepunk.graphics.Image;
 import haxepunk.utils.Color;
+import haxepunk.math.Vector2;
 
 /**
  * Automatic scaling 9-slice graphic.
@@ -96,7 +96,7 @@ class NineSlice extends Graphic
 		return segment;
 	}
 
-	override public function render(point:Point, camera:Camera)
+	override public function render(point:Vector2, camera:Camera)
 	{
 		var leftWidth:Float, rightWidth:Float, topHeight:Float, bottomHeight:Float;
 		if (scaleBorder)

--- a/haxepunk/graphics/atlas/AtlasData.hx
+++ b/haxepunk/graphics/atlas/AtlasData.hx
@@ -2,7 +2,6 @@ package haxepunk.graphics.atlas;
 
 import haxepunk.utils.BlendMode;
 import flash.geom.Rectangle;
-import flash.geom.Point;
 import flash.geom.Matrix;
 import haxepunk.Scene;
 import haxepunk.graphics.shader.Shader;
@@ -10,6 +9,7 @@ import haxepunk.graphics.hardware.DrawCommandBatch;
 import haxepunk.graphics.hardware.Texture;
 import haxepunk.utils.Color;
 import haxepunk.math.MathUtil;
+import haxepunk.math.Vector2;
 
 class AtlasData
 {
@@ -133,7 +133,7 @@ class AtlasData
 	 *
 	 * @return The new AtlasRegion object.
 	 */
-	public inline function createRegion(rect:Rectangle, ?center:Point):AtlasRegion
+	public inline function createRegion(rect:Rectangle, ?center:Vector2):AtlasRegion
 	{
 		return new AtlasRegion(this, rect.clone());
 	}

--- a/haxepunk/graphics/atlas/AtlasRegion.hx
+++ b/haxepunk/graphics/atlas/AtlasRegion.hx
@@ -2,11 +2,11 @@ package haxepunk.graphics.atlas;
 
 import haxepunk.utils.BlendMode;
 import flash.geom.Rectangle;
-import flash.geom.Point;
 import flash.geom.Matrix;
 import haxepunk.utils.Color;
 import haxepunk.math.MathUtil;
 import haxepunk.graphics.shader.Shader;
+import haxepunk.math.Vector2;
 
 class AtlasRegion implements IAtlasRegion
 {
@@ -44,7 +44,7 @@ class AtlasRegion implements IAtlasRegion
 	 * @param	center		The new center point
 	 * @return	A new atlas region with the clipped coordinates
 	 */
-	public function clip(clipRect:Rectangle, ?center:Point):AtlasRegion
+	public function clip(clipRect:Rectangle, ?center:Vector2):AtlasRegion
 	{
 		// make a copy of clipRect, to avoid modifying the original
 		var clipRectCopy = clipRect.clone();

--- a/haxepunk/graphics/atlas/AtlasResolutions.hx
+++ b/haxepunk/graphics/atlas/AtlasResolutions.hx
@@ -1,9 +1,9 @@
 package haxepunk.graphics.atlas;
 
-import haxepunk.utils.BlendMode;
 import flash.geom.Rectangle;
-import flash.geom.Point;
+import haxepunk.utils.BlendMode;
 import haxepunk.graphics.shader.Shader;
+import haxepunk.math.Vector2;
 import haxepunk.utils.Color;
 
 /**
@@ -118,7 +118,7 @@ class AtlasResolutions implements IAtlasRegion
 		);
 	}
 
-	public function clip(clipRect:Rectangle, ?center:Point):IAtlasRegion
+	public function clip(clipRect:Rectangle, ?center:Vector2):IAtlasRegion
 	{
 		var clippedRegions:Array<AtlasRegion> = new Array();
 		clippedRegions.push(base.clip(clipRect, center));
@@ -164,5 +164,5 @@ class AtlasResolutions implements IAtlasRegion
 	}
 
 	static var _rect:Rectangle = new Rectangle();
-	static var _point:Point = new Point();
+	static var _point:Vector2 = new Vector2();
 }

--- a/haxepunk/graphics/atlas/IAtlasRegion.hx
+++ b/haxepunk/graphics/atlas/IAtlasRegion.hx
@@ -1,9 +1,9 @@
 package haxepunk.graphics.atlas;
 
-import haxepunk.utils.BlendMode;
-import flash.geom.Point;
 import flash.geom.Rectangle;
+import haxepunk.utils.BlendMode;
 import haxepunk.graphics.shader.Shader;
+import haxepunk.math.Vector2;
 import haxepunk.utils.Color;
 
 interface IAtlasRegion
@@ -22,6 +22,6 @@ interface IAtlasRegion
 		shader:Shader, smooth:Bool, blend:BlendMode, ?clipRect:Rectangle,
 		flexibleLayer:Bool=false):Void;
 
-	public function clip(clipRect:Rectangle, ?center:Point):IAtlasRegion;
+	public function clip(clipRect:Rectangle, ?center:Vector2):IAtlasRegion;
 	public function destroy():Void;
 }

--- a/haxepunk/graphics/atlas/TextureAtlas.hx
+++ b/haxepunk/graphics/atlas/TextureAtlas.hx
@@ -4,11 +4,11 @@ import haxe.io.Eof;
 import haxe.io.Input;
 import haxe.io.Path;
 import haxe.io.StringInput;
-import flash.geom.Point;
 import flash.geom.Rectangle;
 import flash.Assets;
 import haxepunk.HXP;
 import haxepunk.graphics.atlas.AtlasData;
+import haxepunk.math.Vector2;
 using StringTools;
 
 class TextureAtlas extends Atlas
@@ -90,7 +90,7 @@ class TextureAtlas extends Atlas
 	 *
 	 * @return	The new AtlasRegion object.
 	 */
-	public function defineRegion(name:String, rect:Rectangle, ?center:Point, ?page:String):AtlasRegion
+	public function defineRegion(name:String, rect:Rectangle, ?center:Vector2, ?page:String):AtlasRegion
 	{
 		var data = _pages == null ? this._data : _pages.get(page);
 		var region = data.createRegion(rect, center);

--- a/haxepunk/graphics/emitter/BaseEmitter.hx
+++ b/haxepunk/graphics/emitter/BaseEmitter.hx
@@ -1,13 +1,13 @@
 package haxepunk.graphics.emitter;
 
 import haxepunk.utils.BlendMode;
-import flash.geom.Point;
 import haxepunk.HXP;
 import haxepunk.Graphic;
 import haxepunk.utils.Color;
 import haxepunk.utils.Ease.EaseFunction;
 import haxepunk.math.MathUtil;
 import haxepunk.math.Random;
+import haxepunk.math.Vector2;
 
 @:generic class BaseEmitter<T:Graphic> extends Graphic
 {
@@ -28,7 +28,7 @@ import haxepunk.math.Random;
 		particleCount = 0;
 	}
 
-	override public function render(point:Point, camera:Camera)
+	override public function render(point:Vector2, camera:Camera)
 	{
 		var p:Particle = _particle;
 

--- a/haxepunk/graphics/text/BitmapFontAtlas.hx
+++ b/haxepunk/graphics/text/BitmapFontAtlas.hx
@@ -1,6 +1,7 @@
 package haxepunk.graphics.text;
 
 import flash.Assets;
+import flash.geom.Point;
 import haxe.xml.Fast;
 import haxepunk.HXP;
 import haxepunk.graphics.atlas.AtlasDataType;
@@ -213,10 +214,10 @@ class BitmapFontAtlas extends TextureAtlas implements IBitmapFont
 
 		// remove background color
 		var bgColor32:Int = bitmap.getPixel32(0, 0);
-		bitmap.threshold(bitmap, bitmap.rect, HXP.zero, "==", bgColor32, 0x00000000, 0xFFFFFFFF, true);
+		bitmap.threshold(bitmap, bitmap.rect, _zero, "==", bgColor32, 0x00000000, 0xFFFFFFFF, true);
 
 		if (options.glyphBGColor != null)
-			bitmap.threshold(bitmap, bitmap.rect, HXP.zero, "==", options.glyphBGColor, 0x00000000, 0xFFFFFFFF, true);
+			bitmap.threshold(bitmap, bitmap.rect, _zero, "==", options.glyphBGColor, 0x00000000, 0xFFFFFFFF, true);
 
 		return atlas;
 	}
@@ -243,6 +244,7 @@ class BitmapFontAtlas extends TextureAtlas implements IBitmapFont
 		return lineHeight * size / fontSize;
 	}
 
+	static var _zero:Point = new Point(0, 0);
 	static var _fonts:Map<String, BitmapFontAtlas>;
 	static var _DEFAULT_GLYPHS:String = " !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~";
 }

--- a/haxepunk/graphics/text/BitmapText.hx
+++ b/haxepunk/graphics/text/BitmapText.hx
@@ -1,10 +1,10 @@
 package haxepunk.graphics.text;
 
-import flash.geom.Point;
 import haxepunk.HXP;
 import haxepunk.Graphic;
 import haxepunk.utils.Color;
 import haxepunk.graphics.text.BitmapFontAtlas.BitmapFontFormat;
+import haxepunk.math.Vector2;
 
 /**
  * Text option including the font, size, color, font format...
@@ -594,7 +594,7 @@ class BitmapText extends Graphic
 	}
 
 	@:dox(hide)
-	override public function render(point:Point, camera:Camera)
+	override public function render(point:Vector2, camera:Camera)
 	{
 		if (_dirty) parseText();
 		HXP.clear(_customStack);
@@ -705,7 +705,8 @@ class BitmapText extends Graphic
 					image.scaleX *= this.scale * this.scaleX * _renderData.scale;
 					image.scaleY *= this.scale * this.scaleY * _renderData.scale;
 					image.pixelSnapping = pixelPerfect;
-					image.render(HXP.zero, HXP.zeroCamera);
+					HXP.point.setTo(0, 0);
+					image.render(HXP.point, HXP.zeroCamera);
 					image.x = originalX;
 					image.y = originalY;
 					image.scaleX = originalScaleX;

--- a/haxepunk/graphics/text/Text.hx
+++ b/haxepunk/graphics/text/Text.hx
@@ -3,17 +3,18 @@ package haxepunk.graphics.text;
 import haxe.ds.StringMap;
 import flash.geom.ColorTransform;
 import flash.geom.Matrix;
-import flash.geom.Point;
 import flash.geom.Rectangle;
 import flash.text.TextField;
 import flash.text.TextFormat;
 import flash.text.TextFormatAlign;
 import flash.Assets;
+import flash.geom.Point;
 import haxepunk.HXP;
 import haxepunk.graphics.atlas.Atlas;
 import haxepunk.graphics.atlas.AtlasRegion;
 import haxepunk.graphics.hardware.Texture;
 import haxepunk.utils.Color;
+import haxepunk.math.Vector2;
 
 /**
  * Used for drawing text using embedded fonts.
@@ -539,7 +540,7 @@ class Text extends Image
 	var bufferMargin(get, null):Float;
 	inline function get_bufferMargin() return 2 + (border == null ? 0 : border.size);
 
-	override public function render(point:Point, camera:Camera)
+	override public function render(point:Vector2, camera:Camera)
 	{
 		if (_needsUpdate) updateTextBuffer();
 

--- a/haxepunk/graphics/tile/Backdrop.hx
+++ b/haxepunk/graphics/tile/Backdrop.hx
@@ -1,9 +1,9 @@
 package haxepunk.graphics.tile;
 
-import flash.geom.Point;
 import haxepunk.graphics.atlas.IAtlasRegion;
 import haxepunk.HXP;
 import haxepunk.Graphic;
+import haxepunk.math.Vector2;
 
 /**
  * A background texture that can be repeated horizontally and vertically
@@ -47,7 +47,7 @@ class Backdrop extends Graphic
 	}
 
 	@:dox(hide)
-	override public function render(point:Point, camera:Camera)
+	override public function render(point:Vector2, camera:Camera)
 	{
 		_point.x = (point.x - camera.x * scrollX + x) * camera.fullScaleX;
 		_point.y = (point.y - camera.y * scrollY + y) * camera.fullScaleY;
@@ -88,7 +88,7 @@ class Backdrop extends Graphic
 	}
 
 	@:dox(hide)
-	override public function pixelPerfectRender(point:Point, camera:Camera)
+	override public function pixelPerfectRender(point:Vector2, camera:Camera)
 	{
 		var fsx = camera.fullScaleX,
 			fsy = camera.fullScaleY,

--- a/haxepunk/graphics/tile/TiledImage.hx
+++ b/haxepunk/graphics/tile/TiledImage.hx
@@ -1,8 +1,8 @@
 package haxepunk.graphics.tile;
 
-import flash.geom.Point;
 import flash.geom.Rectangle;
 import haxepunk.Graphic.ImageType;
+import haxepunk.math.Vector2;
 
 /**
  * Special Image object that can display blocks of tiles.
@@ -28,7 +28,7 @@ class TiledImage extends Image
 
 	/** Renders the image. */
 	@:dox(hide)
-	override public function render(point:Point, camera:Camera)
+	override public function render(point:Vector2, camera:Camera)
 	{
 		// determine drawing location
 		_point.x = point.x + x - originX - camera.x * scrollX;
@@ -56,7 +56,7 @@ class TiledImage extends Image
 		}
 	}
 
-	override public function pixelPerfectRender(point:Point, camera:Camera)
+	override public function pixelPerfectRender(point:Vector2, camera:Camera)
 	{
 		// determine drawing location
 		var fsx = camera.fullScaleX,

--- a/haxepunk/graphics/tile/TiledSpritemap.hx
+++ b/haxepunk/graphics/tile/TiledSpritemap.hx
@@ -1,7 +1,7 @@
 package haxepunk.graphics.tile;
 
-import flash.geom.Point;
 import haxepunk.Graphic.TileType;
+import haxepunk.math.Vector2;
 
 /**
  * Special Spritemap object that can display blocks of animated sprites.
@@ -27,7 +27,7 @@ class TiledSpritemap extends Spritemap
 
 	/** Renders the image. */
 	@:dox(hide)
-	override public function render(point:Point, camera:Camera)
+	override public function render(point:Vector2, camera:Camera)
 	{
 		// determine drawing location
 		_point.x = point.x + x - originX - camera.x * scrollX;
@@ -57,7 +57,7 @@ class TiledSpritemap extends Spritemap
 
 	/** Renders the image. */
 	@:dox(hide)
-	override public function pixelPerfectRender(point:Point, camera:Camera)
+	override public function pixelPerfectRender(point:Vector2, camera:Camera)
 	{
 		// determine drawing location
 		_point.x = point.x + floorX(camera, x - originX) - floorX(camera, camera.x * scrollX);

--- a/haxepunk/graphics/tile/Tilemap.hx
+++ b/haxepunk/graphics/tile/Tilemap.hx
@@ -1,11 +1,11 @@
 package haxepunk.graphics.tile;
 
-import flash.geom.Point;
 import flash.geom.Rectangle;
 import haxepunk.Graphic;
 import haxepunk.HXP;
 import haxepunk.graphics.atlas.TileAtlas;
 import haxepunk.masks.Grid;
+import haxepunk.math.Vector2;
 
 /**
  * A rendered grid of tiles.
@@ -381,7 +381,7 @@ class Tilemap extends Graphic
 	}
 
 	@:dox(hide)
-	override public function render(point:Point, camera:Camera)
+	override public function render(point:Vector2, camera:Camera)
 	{
 		var fullScaleX:Float = camera.fullScaleX,
 			fullScaleY:Float = camera.fullScaleY;
@@ -438,7 +438,7 @@ class Tilemap extends Graphic
 	}
 
 	@:dox(hide)
-	override public function pixelPerfectRender(point:Point, camera:Camera)
+	override public function pixelPerfectRender(point:Vector2, camera:Camera)
 	{
 		var fullScaleX:Float = camera.fullScaleX,
 			fullScaleY:Float = camera.fullScaleY;

--- a/haxepunk/input/Gamepad.hx
+++ b/haxepunk/input/Gamepad.hx
@@ -1,6 +1,5 @@
 package haxepunk.input;
 
-import flash.geom.Point;
 #if lime
 import lime.ui.Gamepad as LimeGamepad;
 #else
@@ -8,6 +7,7 @@ import flash.events.JoystickEvent;
 #end
 import haxepunk.HXP;
 import haxepunk.Signal;
+import haxepunk.math.Vector2;
 
 typedef GamepadID = Int;
 typedef GamepadButton = Int;
@@ -166,7 +166,7 @@ class Gamepad
 	/**
 	 * A Point containing the gamepad's hat value.
 	 */
-	public var hat:Point = new Point();
+	public var hat:Vector2 = new Vector2();
 
 	/**
 	 * Creates and initializes a new Gamepad.

--- a/haxepunk/masks/Circle.hx
+++ b/haxepunk/masks/Circle.hx
@@ -7,7 +7,6 @@ import haxepunk.masks.SlopedGrid;
 import haxepunk.utils.Draw;
 import haxepunk.math.Projection;
 import haxepunk.math.Vector2;
-import flash.geom.Point;
 
 /**
  * Uses circular area to determine collision.

--- a/haxepunk/masks/Grid.hx
+++ b/haxepunk/masks/Grid.hx
@@ -1,9 +1,9 @@
 package haxepunk.masks;
 
-import flash.geom.Point;
 import flash.geom.Rectangle;
 import haxepunk.HXP;
 import haxepunk.Mask;
+import haxepunk.math.Vector2;
 
 /**
  * Uses a hash grid to determine collision, faster than
@@ -546,7 +546,7 @@ class Grid extends Hitbox
 	}
 
 	@:dox(hide)
-	public function squareProjection(axis:Point, point:Point):Void
+	public function squareProjection(axis:Vector2, point:Vector2):Void
 	{
 		if (axis.x < axis.y)
 		{
@@ -563,6 +563,6 @@ class Grid extends Hitbox
 	// Grid information.
 	var _tile:Rectangle;
 	var _rect:Rectangle;
-	var _point:Point;
-	var _point2:Point;
+	var _point:Vector2;
+	var _point2:Vector2;
 }

--- a/haxepunk/masks/Hitbox.hx
+++ b/haxepunk/masks/Hitbox.hx
@@ -1,6 +1,5 @@
 package haxepunk.masks;
 
-import flash.geom.Point;
 import haxepunk.Mask;
 import haxepunk.utils.Draw;
 import haxepunk.math.Projection;

--- a/haxepunk/masks/Pixelmask.hx
+++ b/haxepunk/masks/Pixelmask.hx
@@ -1,10 +1,10 @@
 package haxepunk.masks;
 
 import haxepunk.Mask;
-import flash.geom.Point;
 import flash.geom.Rectangle;
 import haxepunk.HXP;
 import haxepunk.graphics.hardware.Texture;
+import haxepunk.math.Vector2;
 
 /**
  * A bitmap mask used for pixel-perfect collision.
@@ -163,6 +163,6 @@ class Pixelmask extends Hitbox
 
 	// Global objects.
 	var _rect:Rectangle;
-	var _point:Point;
-	var _point2:Point;
+	var _point:Vector2;
+	var _point2:Vector2;
 }

--- a/haxepunk/masks/Polygon.hx
+++ b/haxepunk/masks/Polygon.hx
@@ -10,7 +10,6 @@ import haxepunk.math.Projection;
 import haxepunk.math.Vector2;
 import haxepunk.math.MathUtil;
 import haxepunk.math.MakeConvex;
-import flash.geom.Point;
 
 
 /**
@@ -21,7 +20,7 @@ class Polygon extends Hitbox
 	/**
 	 * The polygon rotates around this point when the angle is set.
 	 */
-	public var origin:Point;
+	public var origin:Vector2;
 
 	// Polygon bounding box.
 	/** Left x bounding box position. */
@@ -39,7 +38,7 @@ class Polygon extends Hitbox
 	 * @param	points		An array of coordinates that define the polygon (must have at least 3 and defined counter-clockwise).
 	 * @param	origin	 	Pivot point for rotations.
 	 */
-	public static function fromPoints(points:Array<Vector2>, ?origin:Point):Masklist
+	public static function fromPoints(points:Array<Vector2>, ?origin:Vector2):Masklist
 	{
 		var cp = MakeConvex.run(points);
 		var list = new Masklist();
@@ -53,7 +52,7 @@ class Polygon extends Hitbox
 	 * @param	points		An array of coordinates that define the polygon (must have at least 3 and be convex).
 	 * @param	origin	 	Pivot point for rotations.
 	 */
-	function new(points:Array<Vector2>, ?origin:Point)
+	function new(points:Array<Vector2>, ?origin:Vector2)
 	{
 		super();
 		if (points.length < 3) throw "The polygon needs at least 3 sides.";
@@ -68,7 +67,7 @@ class Polygon extends Hitbox
 		_check.set(Type.getClassName(Circle), collideCircle);
 		_check.set(Type.getClassName(Polygon), collidePolygon);
 
-		this.origin = origin != null ? origin : new Point();
+		this.origin = origin != null ? origin : new Vector2();
 		_angle = 0;
 
 		updateAxes();

--- a/haxepunk/masks/SlopedGrid.hx
+++ b/haxepunk/masks/SlopedGrid.hx
@@ -1,10 +1,10 @@
 package haxepunk.masks;
 
-import flash.geom.Point;
 import flash.geom.Rectangle;
 import haxepunk.HXP;
 import haxepunk.Mask;
 import haxepunk.math.MathUtil;
+import haxepunk.math.Vector2;
 
 @:enum
 abstract TileType(Int)
@@ -524,8 +524,8 @@ class SlopedGrid extends Hitbox
 	// Grid information.
 	var _tile:Rectangle;
 	var _rect:Rectangle;
-	var _point:Point;
-	var _point2:Point;
+	var _point:Vector2;
+	var _point2:Vector2;
 
 	static var _emptyTile:Tile = { type: Empty }; // prevent recreation of empty tile
 }

--- a/haxepunk/tweens/motion/LinearPath.hx
+++ b/haxepunk/tweens/motion/LinearPath.hx
@@ -1,7 +1,7 @@
 package haxepunk.tweens.motion;
 
 import haxepunk.utils.Ease.EaseFunction;
-import flash.geom.Point;
+import haxepunk.math.Vector2;
 
 /**
  * Determines linear motion along a set of points.
@@ -49,7 +49,7 @@ class LinearPath extends Motion
 			distance += Math.sqrt((x - _last.x) * (x - _last.x) + (y - _last.y) * (y - _last.y));
 			_pointD[_points.length] = distance;
 		}
-		_points[_points.length] = _last = new Point(x, y);
+		_points[_points.length] = _last = new Vector2(x, y);
 	}
 
 	/**
@@ -57,7 +57,7 @@ class LinearPath extends Motion
 	 * @param	index		Index of the point.
 	 * @return	The Point object.
 	 */
-	public function getPoint(index:Int = 0):Point
+	public function getPoint(index:Int = 0):Vector2
 	{
 		if (_points.length == 0)
 			throw "No points have been added to the path yet.";
@@ -117,14 +117,14 @@ class LinearPath extends Motion
 	function get_pointCount():Float return _points.length;
 
 	// Path information.
-	var _points:Array<Point> = [];
+	var _points:Array<Vector2> = [];
 	var _pointD:Array<Float> = [0];
 	var _pointT:Array<Float> = [0];
 	var _speed:Float = 0;
 	var _index:Int = 0;
 
 	// Line information.
-	var _last:Point;
-	var _prevPoint:Point;
-	var _nextPoint:Point;
+	var _last:Vector2;
+	var _prevPoint:Vector2;
+	var _nextPoint:Vector2;
 }

--- a/haxepunk/tweens/motion/QuadMotion.hx
+++ b/haxepunk/tweens/motion/QuadMotion.hx
@@ -2,7 +2,7 @@ package haxepunk.tweens.motion;
 
 import haxepunk.HXP;
 import haxepunk.utils.Ease.EaseFunction;
-import flash.geom.Point;
+import haxepunk.math.Vector2;
 
 /**
  * Determines motion along a quadratic curve.
@@ -73,8 +73,8 @@ class QuadMotion extends Motion
 
 	function calculateDistance():Float
 	{
-		var a:Point = HXP.point,
-			b:Point = HXP.point2;
+		var a:Vector2 = HXP.point,
+			b:Vector2 = HXP.point2;
 		a.x = x - 2 * _controlX + _toX;
 		a.y = y - 2 * _controlY + _toY;
 		b.x = 2 * _controlX - 2 * x;

--- a/haxepunk/tweens/motion/QuadPath.hx
+++ b/haxepunk/tweens/motion/QuadPath.hx
@@ -1,7 +1,7 @@
 package haxepunk.tweens.motion;
 
 import haxepunk.utils.Ease.EaseFunction;
-import flash.geom.Point;
+import haxepunk.math.Vector2;
 
 /**
  * A series of points which will determine a path from the
@@ -45,8 +45,8 @@ class QuadPath extends Motion
 	public function addPoint(x:Float = 0, y:Float = 0)
 	{
 		updateInternalCurve = true;
-		if (_points.length == 0) _curve[0] = new Point(x, y);
-		_points[_points.length] = new Point(x, y);
+		if (_points.length == 0) _curve[0] = new Vector2(x, y);
+		_points[_points.length] = new Vector2(x, y);
 	}
 
 	/**
@@ -54,7 +54,7 @@ class QuadPath extends Motion
 	 * @param	index		Index of the point.
 	 * @return	The Point object.
 	 */
-	public function getPoint(index:Int = 0):Point
+	public function getPoint(index:Int = 0):Vector2
 	{
 		if (_points.length == 0)
 			throw "No points have been added to the path yet.";
@@ -98,15 +98,15 @@ class QuadPath extends Motion
 		updateInternalCurve = false;
 
 		// produce the curve points
-		var p:Point,
-			c:Point,
-			l:Point = _points[1],
+		var p:Vector2,
+			c:Vector2,
+			l:Vector2 = _points[1],
 			i:Int = 2;
 		while (i < _points.length)
 		{
 			p = _points[i];
 			if (_curve.length > i - 1) c = _curve[i - 1];
-			else c = _curve[i - 1] = new Point();
+			else c = _curve[i - 1] = new Vector2();
 			if (i < _points.length - 1)
 			{
 				c.x = l.x + (p.x - l.x) / 2;
@@ -148,10 +148,10 @@ class QuadPath extends Motion
 	function get_pointCount():Float return _points.length;
 
 	/** @private Calculates the lenght of the curve. */
-	function curveLength(start:Point, control:Point, finish:Point):Float
+	function curveLength(start:Vector2, control:Vector2, finish:Vector2):Float
 	{
-		var a:Point = HXP.point,
-			b:Point = HXP.point2;
+		var a:Vector2 = HXP.point,
+			b:Vector2 = HXP.point2;
 		a.x = start.x - 2 * control.x + finish.x;
 		a.y = start.y - 2 * control.y + finish.y;
 		b.x = 2 * control.x - 2 * start.x;
@@ -168,19 +168,19 @@ class QuadPath extends Motion
 	}
 
 	// Path information.
-	var _points:Array<Point> = [];
+	var _points:Array<Vector2> = [];
 	var _distance:Float = 0;
 	var _speed:Float = 0;
 	var _index:Int = 0;
 
 	// Curve information.
 	var updateInternalCurve:Bool = true;
-	var _curve:Array<Point> = [];
+	var _curve:Array<Vector2> = [];
 	var _curveT:Array<Float> = [0];
 	var _curveD:Array<Float> = [];
 
 	// Curve points.
-	var _a:Point;
-	var _b:Point;
-	var _c:Point;
+	var _a:Vector2;
+	var _b:Vector2;
+	var _c:Vector2;
 }


### PR DESCRIPTION
This removes all but 4 references to flash.geom.Point in favor of Vector2. It's a step on our way to decoupling from the Flash API.