### PR TITLE
Custom vertex attributes

### DIFF
--- a/haxepunk/graphics/hardware/RenderBuffer.hx
+++ b/haxepunk/graphics/hardware/RenderBuffer.hx
@@ -125,7 +125,7 @@ class RenderBuffer
 	
 	public inline function addVertexAttribData(attribs:Array<Attribute>)
 	{
-		for(attrib in attribs)
+		for (attrib in attribs)
 		{
 			var vPe = attrib.valuesPerElement;
 			var vecs = Std.int(vPe / 2),

--- a/haxepunk/graphics/hardware/RenderBuffer.hx
+++ b/haxepunk/graphics/hardware/RenderBuffer.hx
@@ -123,18 +123,17 @@ class RenderBuffer
 #end
 	}
 	
-	public inline function addVertexAttribData(attribs:Array<Attribute>)
+	/**
+	 * Add vertex attribute data, at the end of the DrawCommand. While position, texture coords
+	 * and color are interleaved, custom vertex attrib data is at the end of the buffer to speed
+	 * up construction.
+	 */
+	public inline function addVertexAttribData(attribs:Array<Attribute>, nbVertices:Int)
 	{
 		for (attrib in attribs)
 		{
-			var vPe = attrib.valuesPerElement;
-			var vecs = Std.int(vPe / 2),
-				ladies = vPe % 2; // 'cause it's a single float ! Hah !
 			var attribData = attrib.data;
-			
-			for (k in 0 ... vecs)
-				addVec(attribData[++attrib.dataPos], attribData[++attrib.dataPos]);
-			if (ladies != 0)
+			for (k in 0 ... nbVertices * attrib.valuesPerElement)
 				addFloat(attribData[++attrib.dataPos]);
 		}
 	}
@@ -154,11 +153,8 @@ class RenderBuffer
 		for (tri in drawCommand.triangles)
 		{
 			addVec(tri.tx1, tri.ty1);
-			addVertexAttribData(attribs);
 			addVec(tri.tx2, tri.ty2);
-			addVertexAttribData(attribs);
 			addVec(tri.tx3, tri.ty3);
-			addVertexAttribData(attribs);
 		}
 	}
 
@@ -171,15 +167,12 @@ class RenderBuffer
 
 			addVec(tri.tx1, tri.ty1);
 			addInt(triangleColor);
-			addVertexAttribData(attribs);
 
 			addVec(tri.tx2, tri.ty2);
 			addInt(triangleColor);
-			addVertexAttribData(attribs);
 
 			addVec(tri.tx3, tri.ty3);
 			addInt(triangleColor);
-			addVertexAttribData(attribs);
 		}
 	}
 
@@ -189,15 +182,12 @@ class RenderBuffer
 		{
 			addVec(tri.tx1, tri.ty1);
 			addVec(tri.uvx1, tri.uvy1);
-			addVertexAttribData(attribs);
 
 			addVec(tri.tx2, tri.ty2);
 			addVec(tri.uvx2, tri.uvy2);
-			addVertexAttribData(attribs);
 
 			addVec(tri.tx3, tri.ty3);
 			addVec(tri.uvx3, tri.uvy3);
-			addVertexAttribData(attribs);
 		}
 	}
 
@@ -211,17 +201,14 @@ class RenderBuffer
 			addVec(tri.tx1, tri.ty1);
 			addVec(tri.uvx1, tri.uvy1);
 			addInt(triangleColor);
-			addVertexAttribData(attribs);
 
 			addVec(tri.tx2, tri.ty2);
 			addVec(tri.uvx2, tri.uvy2);
 			addInt(triangleColor);
-			addVertexAttribData(attribs);
 
 			addVec(tri.tx3, tri.ty3);
 			addVec(tri.uvx3, tri.uvy3);
 			addInt(triangleColor);
-			addVertexAttribData(attribs);
 		}
 	}
 }

--- a/haxepunk/graphics/hardware/RenderBuffer.hx
+++ b/haxepunk/graphics/hardware/RenderBuffer.hx
@@ -148,7 +148,7 @@ class RenderBuffer
 	}
 
 	// Add DrawCommand triangle position only
-	public function prepareVertexOnly(drawCommand:DrawCommand, attribs:Array<Attribute>)
+	public function prepareVertexOnly(drawCommand:DrawCommand)
 	{
 		for (tri in drawCommand.triangles)
 		{
@@ -158,7 +158,7 @@ class RenderBuffer
 		}
 	}
 
-	public function prepareVertexAndColor(drawCommand:DrawCommand, attribs:Array<Attribute>)
+	public function prepareVertexAndColor(drawCommand:DrawCommand)
 	{
 		var triangleColor:UInt = 0;
 		for (tri in drawCommand.triangles)
@@ -176,7 +176,7 @@ class RenderBuffer
 		}
 	}
 
-	public function prepareVertexAndUV(drawCommand:DrawCommand, attribs:Array<Attribute>)
+	public function prepareVertexAndUV(drawCommand:DrawCommand)
 	{
 		for (tri in drawCommand.triangles)
 		{
@@ -191,7 +191,7 @@ class RenderBuffer
 		}
 	}
 
-	public function prepareVertexUVandColor(drawCommand:DrawCommand, attribs:Array<Attribute>)
+	public function prepareVertexUVandColor(drawCommand:DrawCommand)
 	{
 		var triangleColor:UInt = 0;
 		for (tri in drawCommand.triangles)

--- a/haxepunk/graphics/shader/Shader.hx
+++ b/haxepunk/graphics/shader/Shader.hx
@@ -146,20 +146,20 @@ class Shader
 		{
 			if (color.isEnabled)
 			{
-				buffer.prepareVertexUVandColor(drawCommand, attribs);
+				buffer.prepareVertexUVandColor(drawCommand);
 			}
 			else
 			{
-				buffer.prepareVertexAndUV(drawCommand, attribs);
+				buffer.prepareVertexAndUV(drawCommand);
 			}
 		}
 		else if (color.isEnabled)
 		{
-			buffer.prepareVertexAndColor(drawCommand, attribs);
+			buffer.prepareVertexAndColor(drawCommand);
 		}
 		else
 		{
-			buffer.prepareVertexOnly(drawCommand, attribs);
+			buffer.prepareVertexOnly(drawCommand);
 		}
 		
 		buffer.addVertexAttribData(attribs, drawCommand.triangleCount * 3);

--- a/haxepunk/graphics/shader/Shader.hx
+++ b/haxepunk/graphics/shader/Shader.hx
@@ -162,15 +162,18 @@ class Shader
 			buffer.prepareVertexOnly(drawCommand, attribs);
 		}
 		
+		buffer.addVertexAttribData(attribs, drawCommand.triangleCount * 3);
+		
 		buffer.updateGraphicsCard();
 		
-		setAttributePointers();
+		setAttributePointers(drawCommand.triangleCount);
 	}
 
-	function setAttributePointers()
+	function setAttributePointers(nbTriangles:Int)
 	{
 		var offset:Int = 0;
-		var stride:Int = floatsPerVertex * Float32Array.BYTES_PER_ELEMENT;
+		// var stride:Int = floatsPerVertex * Float32Array.BYTES_PER_ELEMENT;
+		var stride:Int = (2 + (texCoord.isEnabled ? 2 : 0) + (color.isEnabled ? 1 : 0)) * Float32Array.BYTES_PER_ELEMENT;
 		GL.vertexAttribPointer(position.index, 2, GL.FLOAT, false, stride, offset);
 		offset += 2 * Float32Array.BYTES_PER_ELEMENT;
 
@@ -186,14 +189,18 @@ class Shader
 			offset += 1 * Float32Array.BYTES_PER_ELEMENT;
 		}
 		
+		// Custom vertex attrib data is at the end of the buffer to speed up construction.
+		
+		offset *= nbTriangles * 3;
+		
 		// Use an array of names to preserve order, since the order of keys in a Map is undefined
 		for (n in attributeNames)
 		{
 			var attrib = attributes[n];
 			if (attrib.isEnabled)
 			{
-				GL.vertexAttribPointer(attrib.index, attrib.valuesPerElement, GL.FLOAT, false, stride, offset);
-				offset += attrib.valuesPerElement * Float32Array.BYTES_PER_ELEMENT;
+				GL.vertexAttribPointer(attrib.index, attrib.valuesPerElement, GL.FLOAT, false, 0, offset);
+				offset += nbTriangles * 3 * attrib.valuesPerElement * Float32Array.BYTES_PER_ELEMENT;
 			}
 		}
 	}

--- a/haxepunk/graphics/shader/Shader.hx
+++ b/haxepunk/graphics/shader/Shader.hx
@@ -32,7 +32,7 @@ class Attribute
 	{
 		name = value;
 		rebind(); // requires name to be set
-		if(index == -1)
+		if (index == -1)
 			trace("Warning : attribute '" + name + "' is not declared or not used in shader source.");
 		return name;
 	}
@@ -62,7 +62,7 @@ class Shader
 	{
 		var a = 2 + (texCoord.isEnabled ? 2 : 0) + (color.isEnabled ? 1 : 0);
 		for (v in attributes.iterator())
-			if(v.isEnabled)
+			if (v.isEnabled)
 				a += v.valuesPerElement;
 		return a;
 	}
@@ -190,7 +190,7 @@ class Shader
 		for (n in attributeNames)
 		{
 			var attrib = attributes[n];
-			if(attrib.isEnabled)
+			if (attrib.isEnabled)
 			{
 				GL.vertexAttribPointer(attrib.index, attrib.valuesPerElement, GL.FLOAT, false, stride, offset);
 				offset += attrib.valuesPerElement * Float32Array.BYTES_PER_ELEMENT;
@@ -229,8 +229,8 @@ class Shader
 		GL.disableVertexAttribArray(position.index);
 		if (texCoord.isEnabled) GL.disableVertexAttribArray(texCoord.index);
 		if (color.isEnabled) GL.disableVertexAttribArray(color.index);
-		for(n in attributeNames)
-			if(attributes[n].isEnabled)
+		for (n in attributeNames)
+			if (attributes[n].isEnabled)
 				GL.disableVertexAttribArray(attributes[n].index);
 	}
 
@@ -299,7 +299,7 @@ class Shader
 			throw "appendVertexAttribData : attribute '" + name + "' was not declared";
 		else
 			attrib = attributes[name];
-		if(values.length % attrib.valuesPerElement != 0)
+		if (values.length % attrib.valuesPerElement != 0)
 			throw "appendVertexAttribData : values per element do not match";
 		attrib.data = attrib.data.concat(values);
 	}

--- a/haxepunk/graphics/shader/Shader.hx
+++ b/haxepunk/graphics/shader/Shader.hx
@@ -139,7 +139,7 @@ class Shader
 	public function prepare(drawCommand:DrawCommand, buffer:RenderBuffer)
 	{
 		if (!position.isEnabled) return;
-		var attribs = attributeNames.map(function(n) return attributes[n]);
+		var attribs = attributeNames.map(function(n) return attributes[n]).filter(function (a) return a.isEnabled);
 
 		buffer.use();
 		if (texCoord.isEnabled)

--- a/haxepunk/graphics/shader/TextureShader.hx
+++ b/haxepunk/graphics/shader/TextureShader.hx
@@ -47,7 +47,7 @@ void main(void) {
 	 */
 	public static inline function fromAsset(name:String):TextureShader
 	{
-		return new TextureShader(Assets.getText(name));
+		return new TextureShader(null, Assets.getText(name));
 	}
 
 	public function new(?vertex:String, ?fragment:String)

--- a/haxepunk/graphics/shader/TextureShader.hx
+++ b/haxepunk/graphics/shader/TextureShader.hx
@@ -50,9 +50,9 @@ void main(void) {
 		return new TextureShader(Assets.getText(name));
 	}
 
-	public function new(?fragment:String)
+	public function new(?vertex:String, ?fragment:String)
 	{
-		super(VERTEX_SHADER, fragment == null ? FRAGMENT_SHADER : fragment);
+		super(vertex == null ? VERTEX_SHADER : vertex, fragment == null ? FRAGMENT_SHADER : fragment);
 		position.name = "aPosition";
 		texCoord.name = "aTexCoord";
 		color.name = "aColor";


### PR DESCRIPTION
Right now one can set custom vertex attributes of 1 to 4 floats (float, vec2, vec3, vec4 ; basically what the OpenGL specification allows). This should eventually be expanded (especially uniforms, really) into being able to set custom vertex attributes of all possible types.