### PR TITLE
Fixed setHitboxTo for HTML5

### DIFF
--- a/haxepunk/Entity.hx
+++ b/haxepunk/Entity.hx
@@ -659,16 +659,6 @@ class Entity extends Tweener
 		this.originY = originY;
 	}
 
-	#if html5 
-	static function getInt( value:Dynamic, defaultValue:Int = 0 ): Int
-	{
-		return if (Std.is(value, Int) || Std.is(value, Float)) 
-			value;
-		else 
-			defaultValue;
-	}
-	#end 
-
 	/**
 	 * Sets the Entity's hitbox to match that of the provided object.
 	 * @param	o		The object defining the hitbox (eg. an Image or Rectangle).
@@ -676,12 +666,22 @@ class Entity extends Tweener
 	public function setHitboxTo(o:Dynamic)
 	{
 		#if html5 
+		inline function getInt( value:Dynamic, defaultValue:Int = 0 ): Int
+		{
+			return if (Std.is(value, Int) || Std.is(value, Float)) 
+				value;
+			else 
+				defaultValue;
+		};
+
 		width = getInt(o.width);
 		height = getInt(o.height);
 
 		originX = getInt(o.originX, -getInt(o.x));
 		originY = getInt(o.originY, -getInt(o.y));
+
 		#else
+
 		inline function getInt(o:Dynamic, prop:String, defaultValue:Int=0):Int
 		{
 			return try
@@ -693,6 +693,7 @@ class Entity extends Tweener
 				defaultValue;
 			}
 		};
+
 		width = getInt(o, "width");
 		height = getInt(o, "height");
 

--- a/haxepunk/Entity.hx
+++ b/haxepunk/Entity.hx
@@ -665,7 +665,7 @@ class Entity extends Tweener
 		return if (Std.is(value, Int) || Std.is(value, Float)) 
 			value;
 		else 
-			defaulValue;
+			defaultValue;
 	}
 	#end 
 

--- a/haxepunk/Entity.hx
+++ b/haxepunk/Entity.hx
@@ -659,24 +659,30 @@ class Entity extends Tweener
 		this.originY = originY;
 	}
 
+	#if html5 
+	static function getInt( value:Dynamic, defaultValue:Int = 0 ): Int{
+		return if( Std.is(value, Int) || Std.is(value, Float) ) 
+			value;
+		else 
+			defaulValue;
+	}
+	#end 
+
 	/**
 	 * Sets the Entity's hitbox to match that of the provided object.
 	 * @param	o		The object defining the hitbox (eg. an Image or Rectangle).
 	 */
 	public function setHitboxTo(o:Dynamic)
 	{
+		#if html5 
+		width = getInt(o.width);
+		height = getInt(o.height);
+
+		originX = getInt(o.originX, -getInt(o.x));
+		originY = getInt(o.originY, -getInt(o.y));
+		#else
 		inline function getInt(o:Dynamic, prop:String, defaultValue:Int=0):Int
 		{
-			#if html5
-			return if ( Reflect.getProperty(o, prop) == null )
-			{
-				defaultValue;
-			}
-			else
-			{
-				Std.int(Reflect.getProperty(o, prop));
-			}
-			#else
 			return try
 			{
 				Std.int(Reflect.getProperty(o, prop));
@@ -685,14 +691,13 @@ class Entity extends Tweener
 			{
 				defaultValue;
 			}
-			#end
 		};
-
 		width = getInt(o, "width");
 		height = getInt(o, "height");
 
 		originX = getInt(o, "originX", -getInt(o, "x"));
 		originY = getInt(o, "originY", -getInt(o, "y"));
+		#end 
 	}
 
 	/**

--- a/haxepunk/Entity.hx
+++ b/haxepunk/Entity.hx
@@ -660,8 +660,9 @@ class Entity extends Tweener
 	}
 
 	#if html5 
-	static function getInt( value:Dynamic, defaultValue:Int = 0 ): Int{
-		return if( Std.is(value, Int) || Std.is(value, Float) ) 
+	static function getInt( value:Dynamic, defaultValue:Int = 0 ): Int
+	{
+		return if (Std.is(value, Int) || Std.is(value, Float)) 
 			value;
 		else 
 			defaulValue;

--- a/haxepunk/Entity.hx
+++ b/haxepunk/Entity.hx
@@ -666,7 +666,7 @@ class Entity extends Tweener
 	public function setHitboxTo(o:Dynamic)
 	{
 		#if html5 
-		inline function getInt( value:Dynamic, defaultValue:Int = 0 ): Int
+		inline function getInt(value:Dynamic, defaultValue:Int = 0):Int
 		{
 			return if (Std.is(value, Int) || Std.is(value, Float)) 
 				value;

--- a/haxepunk/Entity.hx
+++ b/haxepunk/Entity.hx
@@ -667,6 +667,14 @@ class Entity extends Tweener
 	{
 		inline function getInt(o:Dynamic, prop:String, defaultValue:Int=0):Int
 		{
+			#if html5
+			return if ( Reflect.getProperty(o, prop) == null ){
+				defaultValue;
+			}
+			else{
+				Std.int(Reflect.getProperty(o, prop));
+			}
+			#else
 			return try
 			{
 				Std.int(Reflect.getProperty(o, prop));
@@ -675,6 +683,7 @@ class Entity extends Tweener
 			{
 				defaultValue;
 			}
+			#end
 		};
 
 		width = getInt(o, "width");

--- a/haxepunk/Entity.hx
+++ b/haxepunk/Entity.hx
@@ -668,10 +668,12 @@ class Entity extends Tweener
 		inline function getInt(o:Dynamic, prop:String, defaultValue:Int=0):Int
 		{
 			#if html5
-			return if ( Reflect.getProperty(o, prop) == null ){
+			return if ( Reflect.getProperty(o, prop) == null )
+			{
 				defaultValue;
 			}
-			else{
+			else
+			{
 				Std.int(Reflect.getProperty(o, prop));
 			}
 			#else


### PR DESCRIPTION
Fixes a browser platform specific problem(#514) with respect to Std.int
not throwing errors but instead overriding all passed in defaultValue(s)
to zero. This was causing problems for origin x/y being incorrectly
overwritten.

Reflect.hasField could have been used but is only expected to work for
anonymous structures.

- Removed Flash gaurd
- Fixed(?) base git issues