### PR TITLE
Remove reference to flash.geom.Matrix where possible

### DIFF
--- a/haxepunk/HXP.hx
+++ b/haxepunk/HXP.hx
@@ -4,7 +4,6 @@ import haxe.Timer;
 import flash.display.Sprite;
 import flash.display.Stage;
 import flash.display.StageDisplayState;
-import flash.geom.Matrix;
 import flash.ui.Mouse;
 import haxepunk.Tween.TweenType;
 import haxepunk.debug.Console;
@@ -554,7 +553,6 @@ class HXP
 	@:dox(hide) public static var point2:Vector2 = new Vector2();
 	@:dox(hide) public static var zeroCamera:Camera = new Camera();
 	@:dox(hide) public static var rect:Rectangle = new Rectangle();
-	@:dox(hide) public static var matrix:Matrix = new Matrix();
 	@:dox(hide) public static var sprite:Sprite = new Sprite();
 	@:dox(hide) public static var entity:Entity;
 }

--- a/haxepunk/graphics/atlas/AtlasData.hx
+++ b/haxepunk/graphics/atlas/AtlasData.hx
@@ -1,7 +1,6 @@
 package haxepunk.graphics.atlas;
 
 import haxepunk.utils.BlendMode;
-import flash.geom.Matrix;
 import haxepunk.Scene;
 import haxepunk.graphics.shader.Shader;
 import haxepunk.graphics.hardware.DrawCommandBatch;

--- a/haxepunk/graphics/atlas/AtlasRegion.hx
+++ b/haxepunk/graphics/atlas/AtlasRegion.hx
@@ -1,7 +1,6 @@
 package haxepunk.graphics.atlas;
 
 import haxepunk.utils.BlendMode;
-import flash.geom.Matrix;
 import haxepunk.utils.Color;
 import haxepunk.graphics.shader.Shader;
 import haxepunk.math.MathUtil;
@@ -116,10 +115,9 @@ class AtlasRegion implements IAtlasRegion
 	{
 		if (rotated)
 		{
-			var matrix = new Matrix(a, b, c, d, tx, ty);
-			matrix.rotate(90 * MathUtil.RAD);
+			// rotate 90 degrees by inverting values
 			_parent.prepareTileMatrix(_rect,
-				matrix.tx, matrix.ty, matrix.a, matrix.b, matrix.c, matrix.d,
+				-ty, tx, -b, a, -d, c,
 				color, alpha,
 				shader, smooth, blend, clipRect, flexibleLayer
 			);


### PR DESCRIPTION
This is a tiny pull request compared to the last two!

I found that calculating the 90 degree rotated matrix is super fast when you know cos = 0 and sin = 1.

There are still 3 references to Matrix in Text, Imagemask, and Screen. I'm thinking those classes are going to need significant changes or will be lime/nme only.