### PR TITLE
Screen cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
     - HXCPP=3.4.49
   matrix:
     - TEST=no-backend
-    - TEST=nme NME=6.0.58
+    - TEST=nme NME=5.7.1
     - TEST=openfl3 OPENFL=3.6.1 LIME=2.9.1 DOCS=1
     - TEST=openfl4 OPENFL=4.6.0 LIME=3.6.2 DOCS=1
     - TEST=openfl5 OPENFL=5.0.0 LIME=4.1.0

--- a/backend/flash/haxepunk/_internal/TouchInput.hx
+++ b/backend/flash/haxepunk/_internal/TouchInput.hx
@@ -19,7 +19,7 @@ class TouchInput
 
 	static function onTouchBegin(e:TouchEvent)
 	{
-		var touchPoint = new Touch(e.stageX / HXP.screen.fullScaleX, e.stageY / HXP.screen.fullScaleY, e.touchPointID);
+		var touchPoint = new Touch(e.stageX / HXP.screen.scaleX, e.stageY / HXP.screen.scaleY, e.touchPointID);
 		Touch._touches.set(e.touchPointID, touchPoint);
 		Touch._touchOrder.push(e.touchPointID);
 	}
@@ -30,8 +30,8 @@ class TouchInput
 		if (Touch._touches.exists(e.touchPointID))
 		{
 			var point = Touch._touches.get(e.touchPointID);
-			point.x = e.stageX / HXP.screen.fullScaleX;
-			point.y = e.stageY / HXP.screen.fullScaleY;
+			point.x = e.stageX / HXP.screen.scaleX;
+			point.y = e.stageY / HXP.screen.scaleY;
 		}
 	}
 

--- a/examples/asteroids/src/Ship.hx
+++ b/examples/asteroids/src/Ship.hx
@@ -62,7 +62,7 @@ class Ship extends Entity
 		hit = cast collide("asteroid", x, y);
 		if (hit != null)
 		{
-			HXP.screen.shake(0.1,4);
+			scene.camera.shake(0.1,4);
 		}
 
 		while (p != null)

--- a/haxepunk/Camera.hx
+++ b/haxepunk/Camera.hx
@@ -82,6 +82,27 @@ class Camera
 		return entity.collideRect(entity.x, entity.y, x, y, HXP.width, HXP.height);
 	}
 
+	/**
+	 * Cause the screen to shake for a specified length of time.
+	 * @param	duration	Duration of shake effect, in seconds.
+	 * @param	magnitude	Number of pixels to shake in any direction.
+	 * @since	2.5.3
+	 */
+	public function shake(duration:Float = 0.5, magnitude:Int = 4)
+	{
+		if (_shakeTime < duration) _shakeTime = duration;
+		_shakeMagnitude = magnitude;
+	}
+
+	/**
+	 * Stop the screen from shaking immediately.
+	 * @since	2.5.3
+	 */
+	public function shakeStop()
+	{
+		_shakeTime = 0;
+	}
+
 	public function update()
 	{
 		if (anchorTarget != null)
@@ -97,5 +118,32 @@ class Camera
 			x = tx - (HXP.width / fullScaleX * anchorX);
 			y = ty - (HXP.height / fullScaleY * anchorY);
 		}
+
+		// screen shake
+		if (_shakeTime > 0)
+		{
+			var sx:Int = Std.random(_shakeMagnitude * 2 + 1) - _shakeMagnitude;
+			var sy:Int = Std.random(_shakeMagnitude * 2 + 1) - _shakeMagnitude;
+
+			x += sx - _shakeX;
+			y += sy - _shakeY;
+
+			_shakeX = sx;
+			_shakeY = sy;
+
+			_shakeTime -= HXP.elapsed;
+			if (_shakeTime < 0) _shakeTime = 0;
+		}
+		else if (_shakeX != 0 || _shakeY != 0)
+		{
+			x -= _shakeX;
+			y -= _shakeY;
+			_shakeX = _shakeY = 0;
+		}
 	}
+
+	var _shakeTime:Float=0;
+	var _shakeMagnitude:Int=0;
+	var _shakeX:Int=0;
+	var _shakeY:Int=0;
 }

--- a/haxepunk/Camera.hx
+++ b/haxepunk/Camera.hx
@@ -42,9 +42,9 @@ class Camera
 	inline function get_fullScaleY() return scale * scaleY;
 
 	public var screenScaleX(get, never):Float;
-	inline function get_screenScaleX() return fullScaleX * HXP.screen.fullScaleX;
+	inline function get_screenScaleX() return fullScaleX * HXP.screen.scaleX;
 	public var screenScaleY(get, never):Float;
-	inline function get_screenScaleY() return fullScaleY * HXP.screen.fullScaleY;
+	inline function get_screenScaleY() return fullScaleY * HXP.screen.scaleY;
 
 	public var width(get, never):Float;
 	inline function get_width() return HXP.screen.width / screenScaleX;

--- a/haxepunk/Engine.hx
+++ b/haxepunk/Engine.hx
@@ -133,7 +133,10 @@ class Engine
 	 */
 	public function update()
 	{
-		HXP.screen.update();
+		if (HXP.needsResize)
+		{
+			HXP.resize(HXP.windowWidth, HXP.windowHeight);
+		}
 
 		_scene.updateLists();
 		checkScene();

--- a/haxepunk/Engine.hx
+++ b/haxepunk/Engine.hx
@@ -133,7 +133,6 @@ class Engine
 	 */
 	public function update()
 	{
-		if (HXP.screen.needsResize) HXP.resize(HXP.windowWidth, HXP.windowHeight);
 		HXP.screen.update();
 
 		_scene.updateLists();

--- a/haxepunk/HXP.hx
+++ b/haxepunk/HXP.hx
@@ -114,6 +114,11 @@ class HXP
 	 */
 	public static var orientations:Array<Int> = [];
 
+	/**
+	 * True if the scale of the screen has changed.
+	 */
+	public static var needsResize:Bool = false;
+
 	public static var cursor(default, set):Cursor;
 	static inline function set_cursor(cursor:Cursor = null):Cursor
 	{
@@ -186,6 +191,7 @@ class HXP
 		HXP.bounds.width = width;
 		HXP.bounds.height = height;
 		for (scene in HXP.engine) scene._resize();
+		HXP.needsResize = false;
 	}
 
 	/**

--- a/haxepunk/HXP.hx
+++ b/haxepunk/HXP.hx
@@ -35,12 +35,12 @@ class HXP
 	/**
 	 * Width of the window.
 	 */
-	public static var windowWidth:Int;
+	public static var windowWidth:Int = 0;
 
 	/**
 	 * Height of the window.
 	 */
-	public static var windowHeight:Int;
+	public static var windowHeight:Int = 0;
 
 	/**
 	 * If the game is running at a fixed framerate.

--- a/haxepunk/Screen.hx
+++ b/haxepunk/Screen.hx
@@ -48,28 +48,6 @@ class Screen
 		{
 			HXP.resize(HXP.windowWidth, HXP.windowHeight);
 		}
-
-		// screen shake
-		if (_shakeTime > 0)
-		{
-			var sx:Int = Std.random(_shakeMagnitude * 2 + 1) - _shakeMagnitude;
-			var sy:Int = Std.random(_shakeMagnitude * 2 + 1) - _shakeMagnitude;
-
-			x += sx - _shakeX;
-			y += sy - _shakeY;
-
-			_shakeX = sx;
-			_shakeY = sy;
-
-			_shakeTime -= HXP.elapsed;
-			if (_shakeTime < 0) _shakeTime = 0;
-		}
-		else if (_shakeX != 0 || _shakeY != 0)
-		{
-			x -= _shakeX;
-			y -= _shakeY;
-			_shakeX = _shakeY = 0;
-		}
 	}
 
 	/**
@@ -154,33 +132,7 @@ class Screen
 	}
 
 	/**
-	 * Cause the screen to shake for a specified length of time.
-	 * @param	duration	Duration of shake effect, in seconds.
-	 * @param	magnitude	Number of pixels to shake in any direction.
-	 * @since	2.5.3
-	 */
-	public function shake(duration:Float = 0.5, magnitude:Int = 4)
-	{
-		if (_shakeTime < duration) _shakeTime = duration;
-		_shakeMagnitude = magnitude;
-	}
-
-	/**
-	 * Stop the screen from shaking immediately.
-	 * @since	2.5.3
-	 */
-	public function shakeStop()
-	{
-		_shakeTime = 0;
-	}
-
-	/**
 	 * True if the scale of the screen has changed.
 	 */
 	var _needsResize:Bool = false;
-
-	var _shakeTime:Float=0;
-	var _shakeMagnitude:Int=0;
-	var _shakeX:Int=0;
-	var _shakeY:Int=0;
 }

--- a/haxepunk/Screen.hx
+++ b/haxepunk/Screen.hx
@@ -9,7 +9,6 @@ import haxepunk.utils.Color;
  * Container for the main screen buffer. Can be used to transform the screen.
  * To be used through `HXP.screen`.
  */
-@:allow(haxepunk.screen)
 class Screen
 {
 	/**
@@ -55,6 +54,18 @@ class Screen
 	public var y:Int = 0;
 
 	/**
+	 * Width of the screen.
+	 */
+	@:allow(haxepunk.screen)
+	public var width(default, null):Int = 0;
+
+	/**
+	 * Height of the screen.
+	 */
+	@:allow(haxepunk.screen)
+	public var height(default, null):Int = 0;
+
+	/**
 	 * X scale of the screen.
 	 */
 	public var scaleX(default, set):Float = 1;
@@ -88,16 +99,6 @@ class Screen
 	{
 		return Atlas.smooth = value;
 	}
-
-	/**
-	 * Width of the screen.
-	 */
-	public var width(default, null):Int = 0;
-
-	/**
-	 * Height of the screen.
-	 */
-	public var height(default, null):Int = 0;
 
 	/**
 	 * X position of the mouse on the screen.

--- a/haxepunk/Screen.hx
+++ b/haxepunk/Screen.hx
@@ -35,8 +35,8 @@ class Screen
 
 		scaleMode.resize(width, height);
 
-		width = HXP.width = Std.int(HXP.screen.width / HXP.screen.fullScaleX);
-		height = HXP.height = Std.int(HXP.screen.height / HXP.screen.fullScaleY);
+		width = HXP.width = Std.int(HXP.screen.width / HXP.screen.scaleX);
+		height = HXP.height = Std.int(HXP.screen.height / HXP.screen.scaleY);
 
 		_needsResize = false;
 	}
@@ -94,7 +94,6 @@ class Screen
 	function set_scaleX(value:Float):Float
 	{
 		scaleX = value;
-		fullScaleX = scaleX * scale;
 		_needsResize = true;
 		return scaleX;
 	}
@@ -106,34 +105,9 @@ class Screen
 	function set_scaleY(value:Float):Float
 	{
 		scaleY = value;
-		fullScaleY = scaleY * scale;
 		_needsResize = true;
 		return scaleY;
 	}
-
-	/**
-	 * Scale factor of the screen. Final scale is scaleX * scale by scaleY * scale, so
-	 * you can use this factor to scale the screen both horizontally and vertically.
-	 */
-	public var scale(default, set):Float = 1;
-	function set_scale(value:Float):Float
-	{
-		scale = value;
-		fullScaleX = scaleX * scale;
-		fullScaleY = scaleY * scale;
-		_needsResize = true;
-		return scale;
-	}
-
-	/**
-	 * Final X scale value of the screen
-	 */
-	public var fullScaleX(default, null):Float = 1;
-
-	/**
-	 * Final Y scale value of the screen
-	 */
-	public var fullScaleY(default, null):Float = 1;
 
 	/**
 	 * Whether screen smoothing should be used or not.
@@ -162,13 +136,13 @@ class Screen
 	 * X position of the mouse on the screen.
 	 */
 	public var mouseX(get, null):Int;
-	inline function get_mouseX():Int return Std.int((HXP.app.getMouseX() - x) / fullScaleX);
+	inline function get_mouseX():Int return Std.int((HXP.app.getMouseX() - x) / scaleX);
 
 	/**
 	 * Y position of the mouse on the screen.
 	 */
 	public var mouseY(get, null):Int;
-	inline function get_mouseY():Int return Std.int((HXP.app.getMouseY() - y) / fullScaleY);
+	inline function get_mouseY():Int return Std.int((HXP.app.getMouseY() - y) / scaleY);
 
 	/**
 	 * Captures the current screen as an Image object.

--- a/haxepunk/Screen.hx
+++ b/haxepunk/Screen.hx
@@ -37,17 +37,6 @@ class Screen
 
 		width = HXP.width = Std.int(HXP.screen.width / HXP.screen.scaleX);
 		height = HXP.height = Std.int(HXP.screen.height / HXP.screen.scaleY);
-
-		_needsResize = false;
-	}
-
-	@:dox(hide)
-	public function update()
-	{
-		if (_needsResize)
-		{
-			HXP.resize(HXP.windowWidth, HXP.windowHeight);
-		}
 	}
 
 	/**
@@ -72,7 +61,7 @@ class Screen
 	function set_scaleX(value:Float):Float
 	{
 		scaleX = value;
-		_needsResize = true;
+		HXP.needsResize = true;
 		return scaleX;
 	}
 
@@ -83,7 +72,7 @@ class Screen
 	function set_scaleY(value:Float):Float
 	{
 		scaleY = value;
-		_needsResize = true;
+		HXP.needsResize = true;
 		return scaleY;
 	}
 
@@ -130,9 +119,4 @@ class Screen
 	{
 		throw "Screen.capture not currently supported";
 	}
-
-	/**
-	 * True if the scale of the screen has changed.
-	 */
-	var _needsResize:Bool = false;
 }

--- a/haxepunk/Screen.hx
+++ b/haxepunk/Screen.hx
@@ -21,12 +21,7 @@ class Screen
 	 * Constructor.
 	 */
 	@:allow(haxepunk)
-	function new()
-	{
-		x = y = 0;
-		_current = 0;
-		scale = scaleX = scaleY = 1;
-	}
+	function new() {}
 
 	/**
 	 * Resizes the screen.
@@ -43,13 +38,17 @@ class Screen
 		width = HXP.width = Std.int(HXP.screen.width / HXP.screen.fullScaleX);
 		height = HXP.height = Std.int(HXP.screen.height / HXP.screen.fullScaleY);
 
-		_current = 0;
-		needsResize = false;
+		_needsResize = false;
 	}
 
 	@:dox(hide)
 	public function update()
 	{
+		if (_needsResize)
+		{
+			HXP.resize(HXP.windowWidth, HXP.windowHeight);
+		}
+
 		// screen shake
 		if (_shakeTime > 0)
 		{
@@ -81,24 +80,12 @@ class Screen
 	/**
 	 * X offset of the screen.
 	 */
-	public var x(default, set):Int = 0;
-	function set_x(value:Int):Int
-	{
-		if (x == value) return value;
-		x = value;
-		return x;
-	}
+	public var x:Int = 0;
 
 	/**
 	 * Y offset of the screen.
 	 */
-	public var y(default, set):Int = 0;
-	function set_y(value:Int):Int
-	{
-		if (y == value) return value;
-		y = value;
-		return y;
-	}
+	public var y:Int = 0;
 
 	/**
 	 * X scale of the screen.
@@ -106,10 +93,9 @@ class Screen
 	public var scaleX(default, set):Float = 1;
 	function set_scaleX(value:Float):Float
 	{
-		if (scaleX == value) return value;
 		scaleX = value;
 		fullScaleX = scaleX * scale;
-		needsResize = true;
+		_needsResize = true;
 		return scaleX;
 	}
 
@@ -119,10 +105,9 @@ class Screen
 	public var scaleY(default, set):Float = 1;
 	function set_scaleY(value:Float):Float
 	{
-		if (scaleY == value) return value;
 		scaleY = value;
 		fullScaleY = scaleY * scale;
-		needsResize = true;
+		_needsResize = true;
 		return scaleY;
 	}
 
@@ -133,11 +118,10 @@ class Screen
 	public var scale(default, set):Float = 1;
 	function set_scale(value:Float):Float
 	{
-		if (scale == value) return value;
 		scale = value;
 		fullScaleX = scaleX * scale;
 		fullScaleY = scaleY * scale;
-		needsResize = true;
+		_needsResize = true;
 		return scale;
 	}
 
@@ -150,12 +134,6 @@ class Screen
 	 * Final Y scale value of the screen
 	 */
 	public var fullScaleY(default, null):Float = 1;
-
-	/**
-	 * True if the scale of the screen has changed.
-	 */
-	@:dox(hide)
-	public var needsResize(default, null):Bool = false;
 
 	/**
 	 * Whether screen smoothing should be used or not.
@@ -222,7 +200,11 @@ class Screen
 		_shakeTime = 0;
 	}
 
-	var _current:Int;
+	/**
+	 * True if the scale of the screen has changed.
+	 */
+	var _needsResize:Bool = false;
+
 	var _shakeTime:Float=0;
 	var _shakeMagnitude:Int=0;
 	var _shakeX:Int=0;

--- a/haxepunk/cameras/UICamera.hx
+++ b/haxepunk/cameras/UICamera.hx
@@ -11,7 +11,7 @@ class UICamera extends StaticCamera
 	{
 		super.update();
 		scale = 1;
-		scaleX = 1 / HXP.screen.fullScaleX;
-		scaleY = 1 / HXP.screen.fullScaleY;
+		scaleX = 1 / HXP.screen.scaleX;
+		scaleY = 1 / HXP.screen.scaleY;
 	}
 }

--- a/haxepunk/graphics/text/BitmapText.hx
+++ b/haxepunk/graphics/text/BitmapText.hx
@@ -392,8 +392,8 @@ class BitmapText extends Graphic
 		_scaleStack.push(1);
 		_colorStack.push(color);
 		_alphaStack.push(alpha);
-		var fsx:Float = HXP.screen.fullScaleX,
-			fsy:Float = HXP.screen.fullScaleY;
+		var fsx:Float = HXP.screen.scaleX,
+			fsy:Float = HXP.screen.scaleY;
 		var sx:Float = size * scale * scaleX,
 			sy:Float = size * scale * scaleY;
 		var lineHeight:Float = _font.getLineHeight(sy * fsy) / fsy,

--- a/haxepunk/screen/FixedHeightScaleMode.hx
+++ b/haxepunk/screen/FixedHeightScaleMode.hx
@@ -16,8 +16,7 @@ class FixedHeightScaleMode extends ScaleMode
 	{
 		var scale = stageHeight / baseHeight;
 
-		HXP.screen.scale = scale;
-		HXP.screen.scaleX = HXP.screen.scaleY = 1;
+		HXP.screen.scaleX = HXP.screen.scaleY = scale;
 		HXP.screen.x = HXP.screen.y = 0;
 		HXP.screen.width = stageWidth;
 		HXP.screen.height = stageHeight;

--- a/haxepunk/screen/FixedScaleMode.hx
+++ b/haxepunk/screen/FixedScaleMode.hx
@@ -15,6 +15,6 @@ class FixedScaleMode extends ScaleMode
 	{
 		HXP.screen.width = stageWidth;
 		HXP.screen.height = stageHeight;
-		HXP.screen.scale = HXP.screen.scaleX = HXP.screen.scaleY = 1;
+		HXP.screen.scaleX = HXP.screen.scaleY = 1;
 	}
 }

--- a/haxepunk/screen/ScaleMode.hx
+++ b/haxepunk/screen/ScaleMode.hx
@@ -32,7 +32,6 @@ class ScaleMode
 	public function resize(stageWidth:Int, stageHeight:Int)
 	{
 		HXP.screen.x = HXP.screen.y = 0;
-		HXP.screen.scale = 1;
 		HXP.screen.scaleX = stageWidth / baseWidth;
 		HXP.screen.scaleY = stageHeight / baseHeight;
 		HXP.screen.width = stageWidth;

--- a/haxepunk/screen/UniformScaleMode.hx
+++ b/haxepunk/screen/UniformScaleMode.hx
@@ -49,8 +49,7 @@ class UniformScaleMode extends ScaleMode
 			if (scale < 1) scale = 1;
 		}
 
-		HXP.screen.scale = scale;
-		HXP.screen.scaleX = HXP.screen.scaleY = 1;
+		HXP.screen.scaleX = HXP.screen.scaleY = scale;
 		switch (type)
 		{
 			case Letterbox:

--- a/tests/src/haxepunk/ScreenTest.hx
+++ b/tests/src/haxepunk/ScreenTest.hx
@@ -20,6 +20,7 @@ class ScreenTest extends TestSuite
 	{
 		Assert.areEqual(320, HXP.width);
 		Assert.areEqual(480, HXP.height);
-		Assert.areEqual(1.0, HXP.screen.scale);
+		Assert.areEqual(1.0, HXP.screen.scaleX);
+		Assert.areEqual(1.0, HXP.screen.scaleY);
 	}
 }

--- a/tests/src/haxepunk/screen/UniformScaleModeTest.hx
+++ b/tests/src/haxepunk/screen/UniformScaleModeTest.hx
@@ -20,16 +20,16 @@ class UniformScaleModeTest extends TestSuite
 		HXP.screen.scaleMode = new UniformScaleMode();
 
 		HXP.resize(640, 960);
-		Assert.areEqual(2, HXP.screen.fullScaleX);
-		Assert.areEqual(2, HXP.screen.fullScaleY);
+		Assert.areEqual(2, HXP.screen.scaleX);
+		Assert.areEqual(2, HXP.screen.scaleY);
 		Assert.areEqual(320, HXP.width);
 		Assert.areEqual(480, HXP.height);
 		Assert.areEqual(640, HXP.windowWidth);
 		Assert.areEqual(960, HXP.windowHeight);
 
 		HXP.resize(320, 480);
-		Assert.areEqual(1, HXP.screen.fullScaleX);
-		Assert.areEqual(1, HXP.screen.fullScaleY);
+		Assert.areEqual(1, HXP.screen.scaleX);
+		Assert.areEqual(1, HXP.screen.scaleY);
 		Assert.areEqual(320, HXP.width);
 		Assert.areEqual(480, HXP.height);
 		Assert.areEqual(320, HXP.windowWidth);
@@ -42,8 +42,8 @@ class UniformScaleModeTest extends TestSuite
 		HXP.screen.scaleMode = new UniformScaleMode(UniformScaleType.Letterbox);
 
 		HXP.resize(1280, 960);
-		Assert.areEqual(2, HXP.screen.fullScaleX);
-		Assert.areEqual(2, HXP.screen.fullScaleY);
+		Assert.areEqual(2, HXP.screen.scaleX);
+		Assert.areEqual(2, HXP.screen.scaleY);
 		Assert.areEqual(320, HXP.width);
 		Assert.areEqual(480, HXP.height);
 		Assert.areEqual(640, HXP.screen.width);
@@ -54,8 +54,8 @@ class UniformScaleModeTest extends TestSuite
 		Assert.areEqual(0, HXP.screen.y);
 
 		HXP.resize(320, 960);
-		Assert.areEqual(1, HXP.screen.fullScaleX);
-		Assert.areEqual(1, HXP.screen.fullScaleY);
+		Assert.areEqual(1, HXP.screen.scaleX);
+		Assert.areEqual(1, HXP.screen.scaleY);
 		Assert.areEqual(320, HXP.width);
 		Assert.areEqual(480, HXP.height);
 		Assert.areEqual(320, HXP.screen.width);
@@ -66,8 +66,8 @@ class UniformScaleModeTest extends TestSuite
 		Assert.areEqual(240, HXP.screen.y);
 
 		HXP.resize(320, 480);
-		Assert.areEqual(1, HXP.screen.fullScaleX);
-		Assert.areEqual(1, HXP.screen.fullScaleY);
+		Assert.areEqual(1, HXP.screen.scaleX);
+		Assert.areEqual(1, HXP.screen.scaleY);
 		Assert.areEqual(320, HXP.width);
 		Assert.areEqual(480, HXP.height);
 		Assert.areEqual(320, HXP.screen.width);
@@ -84,8 +84,8 @@ class UniformScaleModeTest extends TestSuite
 		HXP.screen.scaleMode = new UniformScaleMode(UniformScaleType.ZoomIn);
 
 		HXP.resize(1280, 960);
-		Assert.areEqual(4, HXP.screen.fullScaleX);
-		Assert.areEqual(4, HXP.screen.fullScaleY);
+		Assert.areEqual(4, HXP.screen.scaleX);
+		Assert.areEqual(4, HXP.screen.scaleY);
 		Assert.areEqual(320, HXP.width);
 		Assert.areEqual(240, HXP.height);
 		Assert.areEqual(1280, HXP.screen.width);
@@ -96,8 +96,8 @@ class UniformScaleModeTest extends TestSuite
 		Assert.areEqual(0, HXP.screen.y);
 
 		HXP.resize(320, 480);
-		Assert.areEqual(1, HXP.screen.fullScaleX);
-		Assert.areEqual(1, HXP.screen.fullScaleY);
+		Assert.areEqual(1, HXP.screen.scaleX);
+		Assert.areEqual(1, HXP.screen.scaleY);
 		Assert.areEqual(320, HXP.width);
 		Assert.areEqual(480, HXP.height);
 		Assert.areEqual(320, HXP.screen.width);
@@ -114,8 +114,8 @@ class UniformScaleModeTest extends TestSuite
 		HXP.screen.scaleMode = new UniformScaleMode(UniformScaleType.Expand);
 
 		HXP.resize(1280, 960);
-		Assert.areEqual(2, HXP.screen.fullScaleX);
-		Assert.areEqual(2, HXP.screen.fullScaleY);
+		Assert.areEqual(2, HXP.screen.scaleX);
+		Assert.areEqual(2, HXP.screen.scaleY);
 		Assert.areEqual(640, HXP.width);
 		Assert.areEqual(480, HXP.height);
 		Assert.areEqual(1280, HXP.screen.width);
@@ -126,8 +126,8 @@ class UniformScaleModeTest extends TestSuite
 		Assert.areEqual(0, HXP.screen.y);
 
 		HXP.resize(320, 480);
-		Assert.areEqual(1, HXP.screen.fullScaleX);
-		Assert.areEqual(1, HXP.screen.fullScaleY);
+		Assert.areEqual(1, HXP.screen.scaleX);
+		Assert.areEqual(1, HXP.screen.scaleY);
 		Assert.areEqual(320, HXP.width);
 		Assert.areEqual(480, HXP.height);
 		Assert.areEqual(320, HXP.screen.width);


### PR DESCRIPTION
* Removing `Screen.scale` and subsequently `Screen.fullScaleX` and `Screen.fullScaleY`
* Moving `Screen.shake()` to `Camera`. This allows UI scenes that don't shake.
* Moving `Screen.needsResize` to `HXP`