### PR TITLE
Fix for #538

### DIFF
--- a/haxepunk/graphics/atlas/TileAtlas.hx
+++ b/haxepunk/graphics/atlas/TileAtlas.hx
@@ -9,15 +9,23 @@ class TileAtlas extends Atlas
 	public var tileCount(get, never):Int;
 	inline function get_tileCount():Int return _regions.length;
 
+	public var tileWidth(get, never):Int;
+	inline function get_tileWidth():Int return _tileWidth;
+	
+	public var tileHeight(get, never):Int;
+	inline function get_tileHeight():Int return _tileHeight;
+
 	/**
 	 * Constructor.
 	 *
 	 * @param	source		Source texture.
 	 */
-	public function new(source:AtlasDataType)
+	public function new(source:AtlasDataType, tileWidth:Int = 0, tileHeight:Int = 0)
 	{
 		super(source);
 		_regions = new Array<AtlasRegion>();
+		_tileWidth = tileWidth;
+		_tileHeight = tileHeight;
 	}
 
 	/**
@@ -50,6 +58,11 @@ class TileAtlas extends Atlas
 			var region = textureAtlas.getRegion(spriteName);
 			atlas._regions.push(region);
 		}
+
+		var region = atlas._regions[0];
+		atlas._tileWidth = region.width;
+		atlas._tileHeight = region.height;
+
 		return atlas;
 	}
 
@@ -63,6 +76,9 @@ class TileAtlas extends Atlas
 	public function prepare(tileWidth:Int, tileHeight:Int, tileMarginWidth:Int=0, tileMarginHeight:Int=0)
 	{
 		if (_regions.length > 0) return; // only prepare once
+		_tileWidth = tileWidth;
+		_tileHeight = tileHeight;
+
 		var cols:Int = Math.floor(_data.width / tileWidth);
 		var rows:Int = Math.floor(_data.height / tileHeight);
 
@@ -85,4 +101,6 @@ class TileAtlas extends Atlas
 	}
 
 	var _regions:Array<AtlasRegion>;
+	var _tileWidth:Int;
+	var _tileHeight:Int;
 }

--- a/haxepunk/graphics/atlas/TileAtlas.hx
+++ b/haxepunk/graphics/atlas/TileAtlas.hx
@@ -5,27 +5,49 @@ import haxepunk.graphics.atlas.AtlasData;
 
 class TileAtlas extends Atlas
 {
-
+	/**
+	 *  The number of tiles.
+	 */
 	public var tileCount(get, never):Int;
 	inline function get_tileCount():Int return _regions.length;
 
+	/**
+	 *  The width of the tiles.
+	 */
 	public var tileWidth(get, never):Int;
 	inline function get_tileWidth():Int return _tileWidth;
 	
+	/**
+	 *  The height of the tiles.
+	 */
 	public var tileHeight(get, never):Int;
 	inline function get_tileHeight():Int return _tileHeight;
+
+	/**
+	 *  The horizontal margin of the tiles.
+	 */
+	public var tileMarginWidth(get, never):Int;
+	inline function get_tileMarginWidth():Int return _tileMarginWidth;
+
+	/**
+	 *  The vertical margin of the tiles.
+	 */
+	public var tileMarginHeight(get, never):Int;
+	inline function get_tileMarginHeight():Int return _tileMarginHeight;
 
 	/**
 	 * Constructor.
 	 *
 	 * @param	source		Source texture.
 	 */
-	public function new(source:AtlasDataType, tileWidth:Int = 0, tileHeight:Int = 0)
+	public function new(source:AtlasDataType, tileWidth:Int = 0, tileHeight:Int = 0, tileMarginWidth:Int = 0, tileMarginHeight:Int = 0)
 	{
 		super(source);
 		_regions = new Array<AtlasRegion>();
 		_tileWidth = tileWidth;
 		_tileHeight = tileHeight;
+		_tileMarginWidth = tileMarginWidth;
+		_tileMarginHeight = tileMarginHeight;
 	}
 
 	/**
@@ -78,6 +100,8 @@ class TileAtlas extends Atlas
 		if (_regions.length > 0) return; // only prepare once
 		_tileWidth = tileWidth;
 		_tileHeight = tileHeight;
+		_tileMarginWidth = tileMarginWidth;
+		_tileMarginHeight = tileMarginHeight;
 
 		var cols:Int = Math.floor(_data.width / tileWidth);
 		var rows:Int = Math.floor(_data.height / tileHeight);
@@ -103,4 +127,6 @@ class TileAtlas extends Atlas
 	var _regions:Array<AtlasRegion>;
 	var _tileWidth:Int;
 	var _tileHeight:Int;
+	var _tileMarginWidth:Int;
+	var _tileMarginHeight:Int;
 }

--- a/haxepunk/graphics/atlas/TileAtlas.hx
+++ b/haxepunk/graphics/atlas/TileAtlas.hx
@@ -2,6 +2,7 @@ package haxepunk.graphics.atlas;
 
 import haxepunk.HXP;
 import haxepunk.graphics.atlas.AtlasData;
+import haxepunk.graphics.atlas.AtlasRegion;
 
 class TileAtlas extends Atlas
 {
@@ -38,16 +39,19 @@ class TileAtlas extends Atlas
 	/**
 	 * Constructor.
 	 *
-	 * @param	source		Source texture.
+	 * @param	source				Source texture.
+	 * @param	tileWidth			Width of the tiles.
+	 * @param	tileHeight			Height of the tiles.
+	 * @param	tileMarginWidth		Horizontal margin of the tiles.
+	 * @param	tileMarginHeight	Vertical margin of the tiles.
 	 */
 	public function new(source:AtlasDataType, tileWidth:Int = 0, tileHeight:Int = 0, tileMarginWidth:Int = 0, tileMarginHeight:Int = 0)
 	{
 		super(source);
 		_regions = new Array<AtlasRegion>();
-		_tileWidth = tileWidth;
-		_tileHeight = tileHeight;
-		_tileMarginWidth = tileMarginWidth;
-		_tileMarginHeight = tileMarginHeight;
+
+		if(tileWidth != 0 && tileHeight != 0)
+			prepare(tileWidth, tileHeight, tileMarginWidth, tileMarginHeight);
 	}
 
 	/**

--- a/haxepunk/graphics/atlas/TileAtlas.hx
+++ b/haxepunk/graphics/atlas/TileAtlas.hx
@@ -50,7 +50,7 @@ class TileAtlas extends Atlas
 		super(source);
 		_regions = new Array<AtlasRegion>();
 
-		if(tileWidth != null && tileHeight != null)
+		if (tileWidth != null && tileHeight != null)
 			prepare(tileWidth, tileHeight, tileMarginWidth, tileMarginHeight);
 	}
 
@@ -109,24 +109,26 @@ class TileAtlas extends Atlas
 		atlas._tileMarginWidth = tileMarginWidth;
 		atlas._tileMarginHeight = tileMarginHeight;
 
-        var cols = Math.floor(region.width / tileWidth);
+		var cols = Math.floor(region.width / tileWidth);
 		var rows = Math.floor(region.height / tileHeight);
 
-        HXP.rect.width = tileWidth;
-        HXP.rect.height = tileHeight;
+		HXP.rect.width = tileWidth;
+		HXP.rect.height = tileHeight;
 
-        HXP.point.x = HXP.point.y = 0;
+		HXP.point.x = HXP.point.y = 0;
 
-        for(y in 0 ... rows) {
-            HXP.rect.y = y * (tileHeight + tileMarginHeight);
+		for (y in 0 ... rows)
+		{
+			HXP.rect.y = y * (tileHeight + tileMarginHeight);
 
-            for(x in 0 ... cols) {
-                HXP.rect.x = x * (tileWidth + tileMarginWidth);
+			for (x in 0 ... cols)
+			{
+				HXP.rect.x = x * (tileWidth + tileMarginWidth);
 
-                var r = region.clip(HXP.rect, HXP.point);
-                atlas._regions.push(r);
-            }
-        }
+				var r = region.clip(HXP.rect, HXP.point);
+				atlas._regions.push(r);
+			}
+		}
 
 		return atlas;
 	}

--- a/haxepunk/graphics/atlas/TileAtlas.hx
+++ b/haxepunk/graphics/atlas/TileAtlas.hx
@@ -45,12 +45,12 @@ class TileAtlas extends Atlas
 	 * @param	tileMarginWidth		Horizontal margin of the tiles.
 	 * @param	tileMarginHeight	Vertical margin of the tiles.
 	 */
-	public function new(source:AtlasDataType, tileWidth:Int = 0, tileHeight:Int = 0, tileMarginWidth:Int = 0, tileMarginHeight:Int = 0)
+	public function new(source:AtlasDataType, ?tileWidth:Int, ?tileHeight:Int, tileMarginWidth:Int = 0, tileMarginHeight:Int = 0)
 	{
 		super(source);
 		_regions = new Array<AtlasRegion>();
 
-		if(tileWidth != 0 && tileHeight != 0)
+		if(tileWidth != null && tileHeight != null)
 			prepare(tileWidth, tileHeight, tileMarginWidth, tileMarginHeight);
 	}
 

--- a/haxepunk/graphics/atlas/TileAtlas.hx
+++ b/haxepunk/graphics/atlas/TileAtlas.hx
@@ -93,6 +93,45 @@ class TileAtlas extends Atlas
 	}
 
 	/**
+	 *  Loads a TileAtlas from a region in another atlas.
+	 *  @param region				An AtlasRegion object to pull tiles from
+	 *  @param tileWidth			Width of the tiles
+	 *  @param tileHeight			Height of the tiles
+	 *  @param tileMarginWidth		Horizontal margin of the tiles
+	 *  @param tileMarginHeight		Vertical margin of the tiles
+	 *  @return A TileAtlas with all packed images defined as regions ordered like a normal tileset.
+	 */
+	public static function loadFromAtlasRegion(region:AtlasRegion, tileWidth:Int, tileHeight:Int, tileMarginWidth:Int=0, tileMarginHeight:Int=0):TileAtlas
+	{
+		@:privateAccess var atlas = new TileAtlas(region._parent);
+		atlas._tileWidth = tileWidth;
+		atlas._tileHeight = tileHeight;
+		atlas._tileMarginWidth = tileMarginWidth;
+		atlas._tileMarginHeight = tileMarginHeight;
+
+        var cols = Math.floor(region.width / tileWidth);
+		var rows = Math.floor(region.height / tileHeight);
+
+        HXP.rect.width = tileWidth;
+        HXP.rect.height = tileHeight;
+
+        HXP.point.x = HXP.point.y = 0;
+
+        for(y in 0 ... rows) {
+            HXP.rect.y = y * (tileHeight + tileMarginHeight);
+
+            for(x in 0 ... cols) {
+                HXP.rect.x = x * (tileWidth + tileMarginWidth);
+
+                var r = region.clip(HXP.rect, HXP.point);
+                atlas._regions.push(r);
+            }
+        }
+
+		return atlas;
+	}
+
+	/**
 	 * Prepares the atlas for drawing.
 	 * @param	tileWidth	With of the tiles.
 	 * @param	tileHeight	Height of the tiles.

--- a/haxepunk/graphics/tile/Tilemap.hx
+++ b/haxepunk/graphics/tile/Tilemap.hx
@@ -471,9 +471,7 @@ class Tilemap extends Graphic
 	function drawTile(tile:Int, tx:Int, ty:Int, x:Float, y:Float, scx:Float, scy:Float)
 	{
 		var region = _atlas.getRegion(tile);
-		_tile.setTo(region.x, region.y, region.width, region.height);
-		_atlas.prepareTile(
-			_tile,
+		region.draw(
 			x, y,
 			scx, scy, 0,
 			color, alpha,
@@ -566,5 +564,4 @@ class Tilemap extends Graphic
 
 	// Tileset information.
 	var _atlas:TileAtlas;
-	static var _tile:Rectangle = new Rectangle();
 }

--- a/haxepunk/graphics/tile/Tilemap.hx
+++ b/haxepunk/graphics/tile/Tilemap.hx
@@ -88,6 +88,7 @@ class Tilemap extends Graphic
 
 		// load the tileset graphic
 		_atlas = tileset;
+		_atlas.prepare(tileWidth, tileHeight, tileSpacingWidth, tileSpacingHeight);
 
 		if (_atlas == null)
 			throw "Invalid tileset graphic provided.";

--- a/haxepunk/graphics/tile/Tilemap.hx
+++ b/haxepunk/graphics/tile/Tilemap.hx
@@ -53,20 +53,37 @@ class Tilemap extends Graphic
 	 * @param	height				Height of the tilemap, in pixels.
 	 * @param	tileWidth			Tile width.
 	 * @param	tileHeight			Tile height.
-	 * @param	tileSpacingWidth	Tile horizontal spacing.
-	 * @param	tileSpacingHeight	Tile vertical spacing.
+	 * @param	tileMarginWidth		Tile horizontal spacing.
+	 * @param	tileMarginHeight	Tile vertical spacing.
 	 */
-	public function new(tileset:TileType, width:Int, height:Int, tileWidth:Int, tileHeight:Int, tileSpacingWidth:Int=0, tileSpacingHeight:Int=0)
+	public function new(tileset:TileType, width:Int, height:Int, tileWidth:Int=0, tileHeight:Int=0, tileMarginWidth:Int=0, tileMarginHeight:Int=0)
 	{
 		// set some tilemap information
 		super();
+	
+		// load the tileset graphic
+		_atlas = tileset;
+
+		if (_atlas == null)
+			throw "Invalid tileset graphic provided.";
+
+		// prepare the tileset if needed
+		if(_atlas.tileWidth == 0 || _atlas.tileHeight == 0)
+		{
+			if(tileWidth == 0 || tileHeight == 0)
+			{
+				throw "Invalid tileset graphic provided.\nThe tileset must be prepared or valid tile dimensions must be passed to the Tilemap constructor.";
+			}
+			else
+			{
+				_atlas.prepare(tileWidth, tileHeight, tileMarginWidth, tileMarginHeight);
+			}
+		}
+
 		this.width = width - (width % tileWidth);
 		this.height = height - (height % tileHeight);
 		_columns = Std.int(this.width / tileWidth);
 		_rows = Std.int(this.height / tileHeight);
-
-		this.tileSpacingWidth = tileSpacingWidth;
-		this.tileSpacingHeight = tileSpacingHeight;
 
 		if (_columns == 0 || _rows == 0)
 			throw "Cannot create a texture of width/height = 0";
@@ -84,13 +101,6 @@ class Tilemap extends Graphic
 				_map[y][x] = -1;
 			}
 		}
-
-		// load the tileset graphic
-		_atlas = tileset;
-		_atlas.prepare(tileWidth, tileHeight, tileSpacingWidth, tileSpacingHeight);
-
-		if (_atlas == null)
-			throw "Invalid tileset graphic provided.";
 
 		pixelSnapping = true;
 	}
@@ -517,14 +527,16 @@ class Tilemap extends Graphic
 	inline function get_tileHeight():Int return _atlas.tileHeight;
 
 	/**
-	 * The tile horizontal spacing of tile.
+	 * The tile horizontal margin of tile.
 	 */
-	public var tileSpacingWidth(default, null):Int;
+	public var tileMarginWidth(get, never):Int;
+	inline function get_tileMarginWidth():Int return _atlas.tileMarginWidth;
 
 	/**
-	 * The tile vertical spacing of tile.
+	 * The tile vertical margin of tile.
 	 */
-	public var tileSpacingHeight(default, null):Int;
+	public var tileMarginHeight(default, null):Int;
+	inline function get_tileMarginHeight():Int return _atlas.tileMarginHeight;
 
 	/**
 	 * How many tiles the tilemap has.

--- a/haxepunk/graphics/tile/Tilemap.hx
+++ b/haxepunk/graphics/tile/Tilemap.hx
@@ -68,9 +68,9 @@ class Tilemap extends Graphic
 			throw "Invalid tileset graphic provided.";
 
 		// prepare the tileset if needed
-		if(_atlas.tileWidth == 0 || _atlas.tileHeight == 0)
+		if (_atlas.tileWidth == 0 || _atlas.tileHeight == 0)
 		{
-			if(tileWidth == null || tileHeight == null)
+			if (tileWidth == null || tileHeight == null)
 			{
 				throw "Invalid tileset graphic provided.\nThe tileset must be prepared or valid tile dimensions must be passed to the Tilemap constructor.";
 			}

--- a/haxepunk/graphics/tile/Tilemap.hx
+++ b/haxepunk/graphics/tile/Tilemap.hx
@@ -2,7 +2,6 @@ package haxepunk.graphics.tile;
 
 import haxepunk.math.Rectangle;
 import haxepunk.Graphic;
-import haxepunk.HXP;
 import haxepunk.graphics.atlas.TileAtlas;
 import haxepunk.masks.Grid;
 import haxepunk.math.Vector2;
@@ -462,9 +461,9 @@ class Tilemap extends Graphic
 	function drawTile(tile:Int, tx:Int, ty:Int, x:Float, y:Float, scx:Float, scy:Float)
 	{
 		var region = _atlas.getRegion(tile);
-		HXP.rect.setTo(region.x, region.y, region.width, region.height);
+		_tile.setTo(region.x, region.y, region.width, region.height);
 		_atlas.prepareTile(
-			HXP.rect,
+			_tile,
 			x, y,
 			scx, scy, 0,
 			color, alpha,
@@ -555,4 +554,5 @@ class Tilemap extends Graphic
 
 	// Tileset information.
 	var _atlas:TileAtlas;
+	static var _tile:Rectangle = new Rectangle();
 }

--- a/haxepunk/graphics/tile/Tilemap.hx
+++ b/haxepunk/graphics/tile/Tilemap.hx
@@ -56,7 +56,7 @@ class Tilemap extends Graphic
 	 * @param	tileMarginWidth		Tile horizontal spacing.
 	 * @param	tileMarginHeight	Tile vertical spacing.
 	 */
-	public function new(tileset:TileType, width:Int, height:Int, tileWidth:Int=0, tileHeight:Int=0, tileMarginWidth:Int=0, tileMarginHeight:Int=0)
+	public function new(tileset:TileType, width:Int, height:Int, ?tileWidth:Int, ?tileHeight:Int, tileMarginWidth:Int=0, tileMarginHeight:Int=0)
 	{
 		// set some tilemap information
 		super();
@@ -70,7 +70,7 @@ class Tilemap extends Graphic
 		// prepare the tileset if needed
 		if(_atlas.tileWidth == 0 || _atlas.tileHeight == 0)
 		{
-			if(tileWidth == 0 || tileHeight == 0)
+			if(tileWidth == null || tileHeight == null)
 			{
 				throw "Invalid tileset graphic provided.\nThe tileset must be prepared or valid tile dimensions must be passed to the Tilemap constructor.";
 			}


### PR DESCRIPTION
This pull addresses the issue outlined in #538.

I couldn't think of any reason that Tilemap should assume that TileAtlas is a gridded tileset with it's origin at (0,0) instead of simply using the regions defined in the atlas.

**Change overview.**

* Moved _tileWidth and _tileHeight from Tilemap to TileAtlas.
* Removed _setCount, _setRows, _setColumns and _tile from Tilemap.
* Changed Tilemap.drawTile() uses data from the AtlasRegion instead of _tile.

**Public API changes:**

* Removed updateTileRect(), getIndex(), getX() and getY() from Tilemap.
