### PR TITLE
Fixed triangle screen check breaking shader with custom vertex attributes

### DIFF
--- a/haxepunk/graphics/hardware/DrawCommand.hx
+++ b/haxepunk/graphics/hardware/DrawCommand.hx
@@ -220,7 +220,7 @@ class DrawCommand
 				MathUtil.maxOf3(tx1, tx2, tx3) >= visibleArea.left &&
 				MathUtil.minOf3(ty1, ty2, ty3) <= visibleArea.bottom &&
 				MathUtil.maxOf3(ty1, ty2, ty3) >= visibleArea.top
-				);
+			);
 			if (onScreen)
 			{
 				var data:DrawTriangle = getData();

--- a/haxepunk/graphics/shader/Shader.hx
+++ b/haxepunk/graphics/shader/Shader.hx
@@ -78,7 +78,7 @@ class Shader
 	public var color:Attribute;
 
 	public var hasAttributes(get, never):Bool;
-	private function get_hasAttributes() : Bool
+	inline function get_hasAttributes() : Bool
 	{
 		return attributeNames.length > 0;
 	}


### PR DESCRIPTION
Every triangle, even those off-screen, need to be drawn if a shader has custom vertex attributes, or else the vertex attrib pointers would not be advanced properly.