### PR TITLE
Fixed instant crash on Neko -debug

### DIFF
--- a/haxepunk/utils/Log.hx
+++ b/haxepunk/utils/Log.hx
@@ -38,7 +38,7 @@ class Log
 	public static inline function write(s:Dynamic, level:LogLevel = LogLevel.Info, ?pos:haxe.PosInfos)
 	{
 		#if (hxp_debug && !(hxp_no_log))
-		haxe.Log.trace(level.format(Std.string(s), pos), null);
+		haxe.Log.trace(level.format(Std.string(s), pos), pos);
 		#end
 	}
 

--- a/haxepunk/utils/Log.hx
+++ b/haxepunk/utils/Log.hx
@@ -38,7 +38,12 @@ class Log
 	public static inline function write(s:Dynamic, level:LogLevel = LogLevel.Info, ?pos:haxe.PosInfos)
 	{
 		#if (hxp_debug && !(hxp_no_log))
-		haxe.Log.trace(level.format(Std.string(s), pos), pos);
+		#if neko
+		var p:haxe.PosInfos = {fileName: "", lineNumber: 0, customParams: null, methodName: "", className: ""};
+		#else
+		var p:haxe.PosInfos = null;
+		#end
+		haxe.Log.trace(level.format(Std.string(s), pos), p);
 		#end
 	}
 


### PR DESCRIPTION
When running a game in Neko with the debug flag, the game would immediately crash due to invalid field access in `haxe.Log.trace`. Looks like this was because the Haxe library's current implementation of `trace` on Neko didn't handle cases where the PosInfos parameter was null. This PR fixes the Log.hx class so that Neko projects can run and log correctly in debug mode.