### PR TITLE
Entity now implicitly casts to Position

### DIFF
--- a/haxepunk/Position.hx
+++ b/haxepunk/Position.hx
@@ -1,8 +1,8 @@
 package haxepunk;
 
 /**
- *  A simple structure to contain the coordinates of a position in 2D space.
- *  Unifies with any object that has x:Float and y:Float variables.
+ * A simple structure to contain the coordinates of a position in 2D space.
+ * Unifies with any object that has x:Float and y:Float variables.
  */
 @:dox(hide)
 private typedef PositionData =
@@ -12,8 +12,8 @@ private typedef PositionData =
 };
 
 /**
- *  Same as PositionData, but unifies with objects (such as Entity)
- *  whose x and y are properties, not variables.
+ * Same as PositionData, but unifies with objects (such as Entity)
+ * whose x and y are properties, not variables.
  */
 @:dox(hide)
 private typedef PositionPropsData =

--- a/haxepunk/Position.hx
+++ b/haxepunk/Position.hx
@@ -1,10 +1,25 @@
 package haxepunk;
 
+/**
+ *  A simple structure to contain the coordinates of a position in 2D space.
+ *  Unifies with any object that has x:Float and y:Float variables.
+ */
 @:dox(hide)
 private typedef PositionData =
 {
 	x:Float,
 	y:Float
+};
+
+/**
+ *  Same as PositionData, but unifies with objects (such as Entity)
+ *  whose x and y are properties, not variables.
+ */
+@:dox(hide)
+private typedef PositionPropsData =
+{
+	@:isVar var x(get, set):Float;
+	@:isVar var y(get, set):Float;
 };
 
 /**
@@ -31,7 +46,7 @@ abstract Position(PositionData) from PositionData to PositionData
 	public var length(get, never):Float;
 	inline function get_length():Float return Math.sqrt(x * x + y * y);
 
-	@:dox(hide) @:from public static inline function fromObject(obj:PositionData) return new Position(obj);
+	@:dox(hide) @:from public static inline function fromProps(obj:PositionPropsData) return new Position(obj);
 
 	public inline function normalize(thickness:Float):Void
 	{


### PR DESCRIPTION
Fixes the problem from #566 where Entities were not converted to Positions when passed as parameters to MathUtil functions. This PR also removes an unnecessary `fromObject()` method from the Position class and adds documentation for the helper structs in `Position.hx` for future reference.