### PR TITLE
Add `callback` parameter to Alarm

### DIFF
--- a/haxepunk/HXP.hx
+++ b/haxepunk/HXP.hx
@@ -420,8 +420,7 @@ class HXP
 		if (type == null) type = TweenType.OneShot;
 		if (tweener == null) tweener = HXP.tweener;
 
-		var alarm:Alarm = new Alarm(delay, type);
-		if (complete != null) alarm.onComplete.bind(complete);
+		var alarm:Alarm = new Alarm(delay, complete, type);
 		tweener.addTween(alarm, true);
 		return alarm;
 	}

--- a/haxepunk/tweens/misc/Alarm.hx
+++ b/haxepunk/tweens/misc/Alarm.hx
@@ -13,9 +13,9 @@ class Alarm extends Tween
 	 * @param	complete	Optional completion callback.
 	 * @param	type		Tween type.
 	 */
-	public function new(duration:Float, ?type:TweenType)
+	public function new(duration:Float, ?complete:Void -> Void, ?type:TweenType)
 	{
-		super(duration, type, null);
+		super(duration, type, complete);
 	}
 
 	/**


### PR DESCRIPTION
Not sure why this was taken out since `Tween` still implements it and the documentation still mentionned it.