### PR TITLE
Updated Scene to return empty containers

### DIFF
--- a/haxepunk/Scene.hx
+++ b/haxepunk/Scene.hx
@@ -954,7 +954,7 @@ class Scene extends Tweener
 	 */
 	public inline function entitiesForType(type:String):List<Entity>
 	{
-		return _types.exists(type) ? _types.get(type) : null;
+		return _types.exists(type) ? _types.get(type) : new List();
 	}
 
 	/**


### PR DESCRIPTION
Scene functions that retrieve entities in arrays or list should return an empty container of whatever they type they return instead of null for consistency's sake.