### PR TITLE
Corrected Xbox bindings for Windows

### DIFF
--- a/backend/lime/haxepunk/_internal/GamepadInput.hx
+++ b/backend/lime/haxepunk/_internal/GamepadInput.hx
@@ -15,7 +15,7 @@ class GamepadInput
 
 	static function onJoyDeviceAdded(limeGamepad:LimeGamepad)
 	{
-		var joy:Gamepad = new Gamepad(limeGamepad.id);
+		var joy:Gamepad = new Gamepad(limeGamepad.id, limeGamepad.name);
 		Gamepad.gamepads[limeGamepad.id] = joy;
 		++Gamepad.gamepadCount;
 

--- a/haxepunk/input/Gamepad.hx
+++ b/haxepunk/input/Gamepad.hx
@@ -55,6 +55,7 @@ class Gamepad
 	public static var gamepadCount(default, null):Int = 0;
 
 	public var id:Int = 0;
+	public var name:String;
 
 	/**
 	 * If the gamepad is currently connected.
@@ -79,9 +80,10 @@ class Gamepad
 	 * Creates and initializes a new Gamepad.
 	 */
 	@:dox(hide)
-	function new(id:Int)
+	function new(id:Int, name:String)
 	{
 		this.id = id;
+		this.name = name;
 	}
 
 	public function update():Void {}

--- a/haxepunk/input/gamepads/XboxGamepad.hx
+++ b/haxepunk/input/gamepads/XboxGamepad.hx
@@ -73,23 +73,23 @@ class XboxGamepad
 	/**
 	 * Button IDs
 	 */
-	public static inline var A_BUTTON:Int = 10;
-	public static inline var B_BUTTON:Int = 11;
-	public static inline var X_BUTTON:Int = 12;
-	public static inline var Y_BUTTON:Int = 13;
-	public static inline var LB_BUTTON:Int = 8;
-	public static inline var RB_BUTTON:Int = 9;
-	public static inline var BACK_BUTTON:Int = 5;
-	public static inline var START_BUTTON:Int = 4;
-	public static inline var LEFT_ANALOGUE_BUTTON:Int = 6;
-	public static inline var RIGHT_ANALOGUE_BUTTON:Int = 7;
+	public static inline var A_BUTTON:Int = 0;
+	public static inline var B_BUTTON:Int = 1;
+	public static inline var X_BUTTON:Int = 2;
+	public static inline var Y_BUTTON:Int = 3;
+	public static inline var BACK_BUTTON:Int = 4;
+	public static inline var START_BUTTON:Int = 6;
+	public static inline var LEFT_ANALOGUE_BUTTON:Int = 7;
+	public static inline var RIGHT_ANALOGUE_BUTTON:Int = 8;
+	public static inline var LB_BUTTON:Int = 9;
+	public static inline var RB_BUTTON:Int = 10;
 
-	public static inline var XBOX_BUTTON:Int = 14;
+	public static inline var XBOX_BUTTON:Int = 5;
 
-	public static inline var DPAD_UP:Int = 0;
-	public static inline var DPAD_DOWN:Int = 1;
-	public static inline var DPAD_LEFT:Int = 2;
-	public static inline var DPAD_RIGHT:Int = 3;
+	public static inline var DPAD_UP:Int = 11;
+	public static inline var DPAD_DOWN:Int = 12;
+	public static inline var DPAD_LEFT:Int = 13;
+	public static inline var DPAD_RIGHT:Int = 14;
 
 	/**
 	 * Axis array indicies


### PR DESCRIPTION
Also adds a `name` field to the Gamepad class that people can use to tell various types of controllers apart. 