### PR TITLE
Fix Grid collisions with Hitbox

### DIFF
--- a/haxepunk/masks/Grid.hx
+++ b/haxepunk/masks/Grid.hx
@@ -321,8 +321,8 @@ class Grid extends Hitbox
 	override function collideHitbox(other:Hitbox):Bool
 	{
 		var rectX:Int, rectY:Int, pointX:Int, pointY:Int;
-		_rect.x = other._parent.x - other._x - _parent.x + _x;
-		_rect.y = other._parent.y - other._y - _parent.y + _y;
+		_rect.x = other._parent.x + other._x - _parent.x + _x;
+		_rect.y = other._parent.y + other._y - _parent.y + _y;
 		pointX = Std.int((_rect.x + other._width  - 1) / _tile.width) + 1;
 		pointY = Std.int((_rect.y + other._height - 1) / _tile.height) + 1;
 		rectX  = Std.int(_rect.x / _tile.width);


### PR DESCRIPTION
I've noticed some unexpected behaviour when using Grid - hitboxes colliding with a wrong offset. This change seems to fix the issue, so I thought I'd send it over for review.

It looks like collideMask might have a similar mistake - but I haven't tested it.