### PR TITLE
Fix using Vector2 as key in maps

### DIFF
--- a/haxepunk/math/Vector2.hx
+++ b/haxepunk/math/Vector2.hx
@@ -20,7 +20,7 @@ private typedef PositionObj =
  * All functions are reentrant.
  */
 @:forward
-abstract Vector2(Position) from Position
+abstract Vector2(Position) from Position to Position
 {
 	public inline function new(x:Float = 0, y:Float = 0)
 	{


### PR DESCRIPTION
Because Map needs to use the underlying type, we need at least an implicit cast between Vector2 and Position, and this gives it.