### PR TITLE
Make NME premultiply assets (consistent with Lime)

### DIFF
--- a/template/project.xml
+++ b/template/project.xml
@@ -14,6 +14,7 @@
 	<haxelib name="HaxePunk"/>
 
 	<haxedef name="hxp_debug" unless="release" />
+	<haxedef name="NME_ALPHA_MODE" value="preprocess" />
 
 	<assets path="assets/graphics" rename="graphics" include="*.png|*.jpg"/>
 	<assets path="assets/audio" rename="audio" include="*.wav|*.ogg"/>


### PR DESCRIPTION
As was discussed in the gitter, this makes it so that the NME backend is consistent with Lime in its treatment of semi-transparent images.