### PR TITLE
Fixed camera and screen scaling

### DIFF
--- a/haxepunk/Scene.hx
+++ b/haxepunk/Scene.hx
@@ -292,7 +292,7 @@ class Scene extends Tweener
 	public var mouseX(get, null):Int;
 	inline function get_mouseX():Int
 	{
-		return Std.int((HXP.app.getMouseX() - HXP.screen.x - x) / camera.screenScaleX + camera.x);
+		return Std.int((HXP.app.getMouseX() - HXP.screen.x - x - HXP.halfWidth) / camera.screenScaleX + camera.x + HXP.halfWidth);
 	}
 
 	/**
@@ -301,7 +301,7 @@ class Scene extends Tweener
 	public var mouseY(get, null):Int;
 	inline function get_mouseY():Int
 	{
-		return Std.int((HXP.app.getMouseY() - HXP.screen.y - y) / camera.screenScaleY + camera.y);
+		return Std.int((HXP.app.getMouseY() - HXP.screen.y - y - HXP.halfHeight) / camera.screenScaleY + camera.y + HXP.halfHeight);
 	}
 
 	/**

--- a/haxepunk/graphics/ColoredRect.hx
+++ b/haxepunk/graphics/ColoredRect.hx
@@ -1,6 +1,7 @@
 package haxepunk.graphics;
 
 import haxepunk.Graphic;
+import haxepunk.HXP;
 import haxepunk.graphics.atlas.AtlasData;
 import haxepunk.graphics.shader.ColorShader;
 import haxepunk.utils.Color;
@@ -30,11 +31,16 @@ class ColoredRect extends Graphic
 
 		var fsx = camera.screenScaleX,
 			fsy = camera.screenScaleY;
-		var x1 = (floorX(camera, point.x) - floorX(camera, camera.x) + floorX(camera, x) - floorX(camera, originX)) * fsx,
-			x2 = x1 + width * fsx,
-			y1 = (floorY(camera, point.y) - floorY(camera, camera.y) + floorY(camera, y) - floorY(camera, originY)) * fsy,
-			y2 = y1 + height * fsy;
-
+		var x1 = floorX(camera, point.x) - floorX(camera, camera.x) + floorX(camera, x) - floorX(camera, originX),
+			x2 = x1 + width,
+			y1 = floorY(camera, point.y) - floorY(camera, camera.y) + floorY(camera, y) - floorY(camera, originY),
+			y2 = y1 + height;
+		
+		x1 = (x1 - HXP.halfWidth) * fsx + HXP.halfWidth;
+		x2 = (x2 - HXP.halfWidth) * fsx + HXP.halfWidth;
+		y1 = (y1 - HXP.halfHeight) * fsx + HXP.halfHeight;
+		y2 = (y2 - HXP.halfHeight) * fsx + HXP.halfHeight;
+		
 		command.addTriangle(x1, y1, 0, 0, x2, y1, 0, 0, x1, y2, 0, 0, color, alpha);
 		command.addTriangle(x1, y2, 0, 0, x2, y1, 0, 0, x2, y2, 0, 0, color, alpha);
 	}

--- a/haxepunk/graphics/Image.hx
+++ b/haxepunk/graphics/Image.hx
@@ -2,6 +2,7 @@ package haxepunk.graphics;
 
 import haxepunk.Camera;
 import haxepunk.Graphic;
+import haxepunk.HXP;
 import haxepunk.graphics.atlas.Atlas;
 import haxepunk.graphics.atlas.IAtlasRegion;
 import haxepunk.graphics.hardware.Texture;
@@ -108,7 +109,8 @@ class Image extends Graphic
 
 			// render without rotation
 			var clipRect = screenClipRect(camera, _point.x, _point.y);
-			_region.draw(_point.x * fsx, _point.y * fsy,
+			_region.draw((_point.x - HXP.halfWidth) * fsx + HXP.halfWidth,
+			 	(_point.y - HXP.halfHeight) * fsy + HXP.halfHeight,
 				sx * fsx, sy * fsy, angle,
 				color, alpha,
 				shader, smooth, blend, clipRect, flexibleLayer
@@ -128,7 +130,9 @@ class Image extends Graphic
 			var tx = (-originX * sx * cos + originY * sy * sin + originX + _point.x);
 			var ty = (-originX * sx * sin - originY * sy * cos + originY + _point.y);
 			var clipRect = screenClipRect(camera, tx, ty);
-			_region.drawMatrix(tx * fsx, ty * fsy, a, b, c, d,
+			_region.drawMatrix((tx - HXP.halfWidth) * fsx + HXP.halfWidth,
+			 	(ty - HXP.halfHeight) * fsy + HXP.halfHeight,
+				a, b, c, d,
 				color, alpha,
 				shader, smooth, blend, clipRect, flexibleLayer
 			);

--- a/haxepunk/graphics/Image.hx
+++ b/haxepunk/graphics/Image.hx
@@ -110,7 +110,7 @@ class Image extends Graphic
 			// render without rotation
 			var clipRect = screenClipRect(camera, _point.x, _point.y);
 			_region.draw((_point.x - HXP.halfWidth) * fsx + HXP.halfWidth,
-			 	(_point.y - HXP.halfHeight) * fsy + HXP.halfHeight,
+				(_point.y - HXP.halfHeight) * fsy + HXP.halfHeight,
 				sx * fsx, sy * fsy, angle,
 				color, alpha,
 				shader, smooth, blend, clipRect, flexibleLayer
@@ -131,7 +131,7 @@ class Image extends Graphic
 			var ty = (-originX * sx * sin - originY * sy * cos + originY + _point.y);
 			var clipRect = screenClipRect(camera, tx, ty);
 			_region.drawMatrix((tx - HXP.halfWidth) * fsx + HXP.halfWidth,
-			 	(ty - HXP.halfHeight) * fsy + HXP.halfHeight,
+				(ty - HXP.halfHeight) * fsy + HXP.halfHeight,
 				a, b, c, d,
 				color, alpha,
 				shader, smooth, blend, clipRect, flexibleLayer

--- a/haxepunk/graphics/text/BitmapText.hx
+++ b/haxepunk/graphics/text/BitmapText.hx
@@ -733,8 +733,8 @@ class BitmapText extends Graphic
 							var x = _renderData.x + lineOffsetX + gd.xOffset * gd.scale / fsx,
 								y = _renderData.y + gd.yOffset * gd.scale * sy / maxFullScale + thisLineHeight - (lineHeight * currentScale * currentSizeRatio);
 							gd.region.draw(
-								(_point.x + floorX(camera, x)) * fsx,
-								(_point.y + floorY(camera, y)) * fsy,
+								(_point.x + floorX(camera, x) - HXP.halfWidth) * fsx + HXP.halfWidth,
+								(_point.y + floorY(camera, y) - HXP.halfHeight) * fsy + HXP.halfHeight,
 								gd.scale, gd.scale * sy * fsy / maxFullScale, 0,
 								_renderData.color, _renderData.alpha,
 								shader, smooth, blend, clipRect, flexibleLayer
@@ -766,11 +766,13 @@ class BitmapText extends Graphic
 					_renderData.scale = currentScale;
 					applyCustomFunctions(_renderData);
 					image.x = _point.x + _renderData.x + lineOffsetX + originalX + padding;
+					image.x = (image.x - HXP.halfWidth) * fsx + HXP.halfWidth;
 					image.y = _point.y + _renderData.y + thisLineHeight + originalY - image.height * image.scale * image.scaleY * _renderData.scale * this.scale * this.scaleY;
+					image.y = (image.y - HXP.halfHeight) * fsy + HXP.halfHeight;
 					image.color = _renderData.color;
 					image.alpha = _renderData.alpha;
-					image.scaleX *= this.scale * this.scaleX * _renderData.scale;
-					image.scaleY *= this.scale * this.scaleY * _renderData.scale;
+					image.scaleX *= this.scale * this.scaleX * _renderData.scale * fsx;
+					image.scaleY *= this.scale * this.scaleY * _renderData.scale * fsy;
 					image.pixelSnapping = pixelPerfect;
 					HXP.point.setTo(0, 0);
 					image.render(HXP.point, HXP.zeroCamera);

--- a/haxepunk/graphics/tile/Backdrop.hx
+++ b/haxepunk/graphics/tile/Backdrop.hx
@@ -54,17 +54,19 @@ class Backdrop extends Graphic
 		originX = _width * 0.5;
 		originY = _height * 0.5;
 	}
-
+	
 	@:dox(hide)
 	override public function render(point:Vector2, camera:Camera)
 	{
-		_point.x = (point.x - camera.x * scrollX + x) * camera.screenScaleX - originX * scaleX * scale;
-		_point.y = (point.y - camera.y * scrollY + y) * camera.screenScaleY - originY * scaleY * scale;
-
-		var sx = scale * scaleX * camera.screenScaleX,
-			sy = scale * scaleY * camera.screenScaleY,
-			scaledWidth = _width * sx,
-			scaledHeight = _height * sy;
+		var fsx = camera.screenScaleX,
+			fsy = camera.screenScaleY,
+			sx = scale * scaleX,
+			sy = scale * scaleY,
+			scaledWidth = _width * sx * fsx,
+			scaledHeight = _height * sy * fsy;
+		
+		_point.x = (point.x - camera.x * scrollX + x - HXP.halfWidth - originX * sx) * fsx + HXP.halfWidth ;
+		_point.y = (point.y - camera.y * scrollY + y - HXP.halfHeight - originY * sy) * fsy + HXP.halfHeight ;
 
 		var xi:Int = 1,
 			yi:Int = 1;
@@ -85,10 +87,9 @@ class Backdrop extends Graphic
 		{
 			for (x in 0 ... xi)
 			{
-				_region.draw(
-					_point.x + x * scaledWidth,
+				_region.draw(_point.x + x * scaledWidth,
 					_point.y + y * scaledHeight,
-					sx, sy, 0,
+					sx * fsx, sy * fsy, 0,
 					color, alpha,
 					shader, smooth, blend
 				);
@@ -103,8 +104,8 @@ class Backdrop extends Graphic
 			fsy = camera.screenScaleY,
 			sx = scale * scaleX,
 			sy = scale * scaleY;
-		_point.x = (floorX(camera, point.x) + floorX(camera, x) - floorX(camera, originX * sx) - floorX(camera, camera.x * scrollX)) * fsx;
-		_point.y = (floorY(camera, point.y) + floorY(camera, y) - floorY(camera, originY * sy) - floorY(camera, camera.y * scrollY)) * fsy;
+		_point.x = (floorX(camera, point.x) + floorX(camera, x) - floorX(camera, originX * sx) - floorX(camera, camera.x * scrollX) - HXP.halfWidth) * fsx + HXP.halfWidth;
+		_point.y = (floorY(camera, point.y) + floorY(camera, y) - floorY(camera, originY * sy) - floorY(camera, camera.y * scrollY) - HXP.halfHeight) * fsy + HXP.halfHeight;
 
 		var scaledWidth = _width * sx * fsx,
 			scaledHeight = _height * sy * fsy;

--- a/haxepunk/graphics/tile/TiledImage.hx
+++ b/haxepunk/graphics/tile/TiledImage.hx
@@ -1,5 +1,6 @@
 package haxepunk.graphics.tile;
 
+import haxepunk.HXP;
 import haxepunk.math.Rectangle;
 import haxepunk.Graphic.ImageType;
 import haxepunk.math.Vector2;
@@ -44,7 +45,8 @@ class TiledImage extends Image
 		{
 			while (x < _width)
 			{
-				_region.draw(Math.floor((_point.x + x) * fsx), Math.floor((_point.y + y) * fsy),
+				_region.draw(Math.floor((_point.x + x - HXP.halfWidth) * fsx + HXP.halfWidth),
+					Math.floor((_point.y + y - HXP.halfHeight) * fsy + HXP.halfHeight),
 					sx, sy, angle,
 					color, alpha,
 					shader, smooth, blend
@@ -63,8 +65,8 @@ class TiledImage extends Image
 			fsy = camera.screenScaleY,
 			sx = scale * scaleX,
 			sy = scale * scaleY;
-		_point.x = (point.x + floorX(camera, x - originX) - floorX(camera, camera.x * scrollX)) * fsx;
-		_point.y = (point.y + floorY(camera, y - originY) - floorY(camera, camera.y * scrollY)) * fsy;
+		_point.x = (point.x + floorX(camera, x - originX) - floorX(camera, camera.x * scrollX) - HXP.halfWidth) * fsx + HXP.halfWidth;
+		_point.y = (point.y + floorY(camera, y - originY) - floorY(camera, camera.y * scrollY) - HXP.halfHeight) * fsy + HXP.halfHeight;
 
 		var x:Float = 0, y:Float = 0,
 			x1:Float = 0, y1:Float = 0,
@@ -73,7 +75,7 @@ class TiledImage extends Image
 		{
 			y += _sourceRect.height * sy;
 			y2 = floorY(camera, y) * fsy;
-			while (x1 < _width * sx)
+			while (x < _width * sx)
 			{
 				x += _sourceRect.width * sx;
 				x2 = floorX(camera, x) * fsx;

--- a/haxepunk/graphics/tile/TiledSpritemap.hx
+++ b/haxepunk/graphics/tile/TiledSpritemap.hx
@@ -1,5 +1,6 @@
 package haxepunk.graphics.tile;
 
+import haxepunk.HXP;
 import haxepunk.Graphic.TileType;
 import haxepunk.math.Vector2;
 
@@ -24,7 +25,7 @@ class TiledSpritemap extends Spritemap
 
 		pixelSnapping = true;
 	}
-
+	
 	/** Renders the image. */
 	@:dox(hide)
 	override public function render(point:Vector2, camera:Camera)
@@ -43,7 +44,8 @@ class TiledSpritemap extends Spritemap
 		{
 			while (x < _imageWidth)
 			{
-				_region.draw(Math.floor((_point.x + x) * fsx), Math.floor((_point.y + y) * fsy),
+				_region.draw(Math.floor((_point.x + x - HXP.halfWidth) * fsx + HXP.halfWidth),
+					Math.floor((_point.y + y - HXP.halfHeight) * fsy + HXP.halfHeight),
 					sx, sy, angle,
 					color, alpha,
 					shader, smooth, blend
@@ -60,14 +62,12 @@ class TiledSpritemap extends Spritemap
 	override public function pixelPerfectRender(point:Vector2, camera:Camera)
 	{
 		// determine drawing location
-		_point.x = point.x + floorX(camera, x - originX) - floorX(camera, camera.x * scrollX);
-		_point.y = point.y + floorY(camera, y - originY) - floorY(camera, camera.y * scrollY);
-
 		var fsx = camera.screenScaleX,
 			fsy = camera.screenScaleY,
-			sx = fsx * scale * scaleX,
-			sy = fsy * scale * scaleY,
-			x = 0.0, y = 0.0;
+			sx = scale * scaleX,
+			sy = scale * scaleY;
+		_point.x = (point.x + floorX(camera, x - originX) - floorX(camera, camera.x * scrollX) - HXP.halfWidth) * fsx + HXP.halfWidth;
+		_point.y = (point.y + floorY(camera, y - originY) - floorY(camera, camera.y * scrollY) - HXP.halfHeight) * fsy + HXP.halfHeight;
 
 		var x:Float = 0, y:Float = 0,
 			x1:Float = 0, y1:Float = 0,
@@ -76,7 +76,7 @@ class TiledSpritemap extends Spritemap
 		{
 			y += _sourceRect.height * sy;
 			y2 = floorY(camera, y) * fsy;
-			while (x1 < _imageWidth * sx)
+			while (x < _imageWidth * sx)
 			{
 				x += _sourceRect.width * sx;
 				x2 = floorX(camera, x) * fsx;

--- a/haxepunk/graphics/tile/Tilemap.hx
+++ b/haxepunk/graphics/tile/Tilemap.hx
@@ -366,7 +366,7 @@ class Tilemap extends Graphic
 		originX = width * 0.5;
 		originY = height * 0.5;
 	}
-
+	
 	@:dox(hide)
 	override public function render(point:Vector2, camera:Camera)
 	{
@@ -374,19 +374,19 @@ class Tilemap extends Graphic
 			fullScaleY:Float = camera.screenScaleY;
 
 		// determine drawing location
-		_point.x = point.x + x - originX - camera.x * scrollX;
-		_point.y = point.y + y - originY - camera.y * scrollY;
+		_point.x = (point.x + x - originX - camera.x * scrollX - HXP.halfWidth) * fullScaleX + HXP.halfWidth;
+		_point.y = (point.y + y - originY - camera.y * scrollY - HXP.halfHeight) * fullScaleX + HXP.halfHeight;
 
 		var scx = scale * scaleX,
 			scy = scale * scaleY,
-			tw = tileWidth * scx,
-			th = tileHeight * scy;
+			tw = tileWidth * scx * fullScaleX,
+			th = tileHeight * scy * fullScaleY;
 
 		// determine start and end tiles to draw (optimization)
 		var startx = Math.floor(-_point.x / tw),
 			starty = Math.floor(-_point.y / th),
-			destx = startx + 1 + Math.ceil(HXP.width / camera.scale / camera.scaleX / tw),
-			desty = starty + 1 + Math.ceil(HXP.height / camera.scale / camera.scaleY / th);
+			destx = startx + 1 + Math.ceil(HXP.width / tw),
+			desty = starty + 1 + Math.ceil(HXP.height / th);
 
 		// nothing will render if we're completely off screen
 		if (startx > _columns || starty > _rows || destx < 0 || desty < 0)
@@ -398,11 +398,8 @@ class Tilemap extends Graphic
 		if (starty < 0) starty = 0;
 		if (desty > _rows) desty = _rows;
 
-		var wx:Float, wy:Float, nx:Float, ny:Float,
-			tile:Int = 0;
-
-		_point.x *= fullScaleX;
-		_point.y *= fullScaleY;
+		var tile:Int = 0;
+		
 		for (y in starty...desty)
 		{
 			for (x in startx...destx)
@@ -412,8 +409,8 @@ class Tilemap extends Graphic
 				{
 					drawTile(
 						tile, x, y,
-						_point.x + x * tw * fullScaleX,
-						_point.y + y * th * fullScaleY,
+						_point.x + x * tw,
+						_point.y + y * th,
 						scx * fullScaleX, scy * fullScaleY
 					);
 				}
@@ -434,13 +431,15 @@ class Tilemap extends Graphic
 
 		// determine drawing location
 		_point.x = point.x + floorX(camera, x) - floorX(camera, originX * scx) - floorX(camera, camera.x * scrollX);
+		_point.x = (_point.x - HXP.halfWidth) * fullScaleX + HXP.halfWidth;
 		_point.y = point.y + floorY(camera, y) - floorY(camera, originY * scy) - floorY(camera, camera.y * scrollY);
+		_point.y = (_point.y - HXP.halfHeight) * fullScaleY + HXP.halfHeight;
 
 		// determine start and end tiles to draw (optimization)
-		var startx = Math.floor(-_point.x / tw),
-			starty = Math.floor(-_point.y / th),
-			destx = startx + 1 + Math.ceil(HXP.width / camera.scale / camera.scaleX / tw),
-			desty = starty + 1 + Math.ceil(HXP.height / camera.scale / camera.scaleY / th);
+		var startx = Math.floor(-_point.x / tw / fullScaleX),
+			starty = Math.floor(-_point.y / th / fullScaleY),
+			destx = startx + 1 + Math.ceil(HXP.width / tw / fullScaleX),
+			desty = starty + 1 + Math.ceil(HXP.height / th / fullScaleY);
 
 		// nothing will render if we're completely off screen
 		if (startx > _columns || starty > _rows || destx < 0 || desty < 0)
@@ -455,8 +454,6 @@ class Tilemap extends Graphic
 		var wx:Float, wy:Float, nx:Float, ny:Float,
 			tile:Int = 0;
 
-		_point.x *= fullScaleX;
-		_point.y *= fullScaleY;
 		wy = floorY(camera, starty * th) * fullScaleY;
 		for (y in starty...desty)
 		{


### PR DESCRIPTION
Up until now, camera and screen scaling (zooming) was done relative to the top-left corner, which isn't really useful. This makes it so that the scaling is done relative to the center of the screen.