### PR TITLE
Do not render unready scenes

### DIFF
--- a/haxepunk/Engine.hx
+++ b/haxepunk/Engine.hx
@@ -377,7 +377,7 @@ private class VisibleSceneIterator
 		while (i >= 0)
 		{
 			scene = engine._scenes[i];
-			if (scene.visible)
+			if (scene.visible && scene.added)
 			{
 				scenes.push(scene);
 			}


### PR DESCRIPTION
Under very specific circumstances, the Engine class would render scenes before their `begin()` function was called.