### PR TITLE
Do not render unready scenes

### DIFF
--- a/haxepunk/Engine.hx
+++ b/haxepunk/Engine.hx
@@ -377,7 +377,7 @@ private class VisibleSceneIterator
 		while (i >= 0)
 		{
 			scene = engine._scenes[i];
-			if (scene.visible)
+			if (scene.visible && scene.started)
 			{
 				scenes.push(scene);
 			}


### PR DESCRIPTION
Under very specific circumstances, Engine could render a scene before its `begin()` method was called.