### PR TITLE
Solution for projects on Windows

### DIFF
--- a/tools/Project.hx
+++ b/tools/Project.hx
@@ -140,6 +140,9 @@ class Project
 
 					CLI.print(filename);
 
+					// Windows will throw if a file is opened and its folder wasn't created yet
+					createDirectory(path + "/" + Path.directory(filename) + "/"); 
+
 					var fout:FileOutput = File.write(path + "/" + filename, true);
 					fout.writeBytes(bytes, 0, bytes.length);
 					fout.close();

--- a/tools/Run.hx
+++ b/tools/Run.hx
@@ -27,8 +27,11 @@ class Run
 		if (!FileSystem.exists(template))
 		{
 			Sys.setCwd(path);
-
-			Sys.command("make", ["template.zip"]);
+ 
+			// copy template folder to zip file
+			var out = sys.io.File.write("template.zip", true);
+			var zip = new haxe.zip.Writer(out);
+			zip.write(getEntries("template/"));
 
 			Sys.setCwd(cwd);
 		}
@@ -40,6 +43,8 @@ class Run
 
 		// Call tool.n without the cwd passed by haxelib
 		args.unshift(tool);
+
+		// Enter the directory provided by haxelib
 		Sys.setCwd(dir);
 
 		var code = Sys.command("neko", args);
@@ -47,4 +52,47 @@ class Run
 		Sys.setCwd(cwd);
 		Sys.exit(code);
 	}
+
+
+	/** 
+	* Recursively copies a directory. 
+	* @param dir The directory to copy for compression.
+	* @return A list of zip entries, to be passed to the writer.
+	* @source: https://code.haxe.org/category/other/haxe-zip.html
+	* @author: Mark Knol
+	**/
+	private static function getEntries(dir:String, entries:List<haxe.zip.Entry> = null, inDir:Null<String> = null):List<haxe.zip.Entry> {
+		if (entries == null)
+		{
+			entries = new List<haxe.zip.Entry>();
+		}
+		if (inDir == null){
+			inDir = dir;
+		}
+		for (file in sys.FileSystem.readDirectory(dir)) 
+		{
+			var path = haxe.io.Path.join([dir, file]);
+			if (sys.FileSystem.isDirectory(path)) 
+			{
+				getEntries(path, entries, inDir);
+			} 
+			else 
+			{
+				var bytes:haxe.io.Bytes = haxe.io.Bytes.ofData(sys.io.File.getBytes(path).getData());
+				var entry:haxe.zip.Entry = {
+					fileName: StringTools.replace(path, inDir, ""), 
+					fileSize: bytes.length,
+					fileTime: Date.now(),
+					compressed: false,
+					dataSize: 0,
+					data: bytes,
+					crc32: haxe.crypto.Crc32.make(bytes)
+				};
+				entries.push(entry);
+			}
+		}
+		return entries;
+	}
+
+
 }

--- a/tools/Run.hx
+++ b/tools/Run.hx
@@ -27,7 +27,7 @@ class Run
 		if (!FileSystem.exists(template))
 		{
 			Sys.setCwd(path);
- 
+
 			// copy template folder to zip file
 			var out = sys.io.File.write("template.zip", true);
 			var zip = new haxe.zip.Writer(out);
@@ -53,7 +53,6 @@ class Run
 		Sys.exit(code);
 	}
 
-
 	/** 
 	* Recursively copies a directory. 
 	* @param dir The directory to copy for compression.
@@ -61,12 +60,14 @@ class Run
 	* @source: https://code.haxe.org/category/other/haxe-zip.html
 	* @author: Mark Knol
 	**/
-	private static function getEntries(dir:String, entries:List<haxe.zip.Entry> = null, inDir:Null<String> = null):List<haxe.zip.Entry> {
+	private static function getEntries(dir:String, ?entries:List<haxe.zip.Entry>, ?inDir:Null<String>):List<haxe.zip.Entry> 
+	{
 		if (entries == null)
 		{
 			entries = new List<haxe.zip.Entry>();
 		}
-		if (inDir == null){
+		if (inDir == null)
+		{
 			inDir = dir;
 		}
 		for (file in sys.FileSystem.readDirectory(dir)) 
@@ -93,6 +94,5 @@ class Run
 		}
 		return entries;
 	}
-
 
 }


### PR DESCRIPTION
# Fix
This will fix any issues in the inital "run" from haxelib, on any OS, where the template folder needs to be compressed into a zip file. The original implementation relied on external dependencies like "make" and "zip" which some OS's (many window variants) don't have.

## Changed code
You can see the original make call has been replaced with a `haxe.zip` implementation.

The `getEntries` function is exactly the one found in the haxe cookbook: https://code.haxe.org/category/other/haxe-zip.html


## Files Changed
**Run.hx**: Added the OS agnostic template compression.

**Project.hx**: Since this never worked on windows, the line I added was to fix a small bug that was never come across. 