### PR TITLE
Anchor fixed

### DIFF
--- a/haxepunk/Camera.hx
+++ b/haxepunk/Camera.hx
@@ -1,6 +1,12 @@
 package haxepunk;
 
+import haxe.ds.Either.Left;
+import haxe.ds.Either.Right;
 import haxepunk.math.Vector2;
+import haxepunk.ds.OneOf;
+
+@:dox(hide)
+typedef CamPoint = OneOf<PositionObj,Vector2>;
 
 /**
  * @since 4.0.0
@@ -63,7 +69,7 @@ class Camera
 	 */
 	public inline function floorY(y:Float) return Math.floor((y + 0.5) * screenScaleY) / screenScaleY;
 
-	var anchorTarget:Null<Vector2>;
+	var anchorTarget:Null<CamPoint>;
 	var anchorX:Float = 0;
 	var anchorY:Float = 0;
 
@@ -72,9 +78,9 @@ class Camera
 	 * Camera will keep the target in the specified part of the screen.
 	 * @since 4.0.0
 	 */
-	public function anchor(?target:Vector2, anchorX:Float = 0.5, anchorY:Float = 0.5)
+	public function anchor(?targetL:PositionObj, ?targetR:Vector2, anchorX:Float = 0.5, anchorY:Float = 0.5)
 	{
-		anchorTarget = target;
+		anchorTarget = (targetL != null)? targetL : targetR;		
 		this.anchorX = anchorX;
 		this.anchorY = anchorY;
 	}
@@ -107,16 +113,26 @@ class Camera
 
 	public function update()
 	{
+
 		if (anchorTarget != null)
 		{
-			var tx = anchorTarget.x,
-				ty = anchorTarget.y;
-			if (Std.is(anchorTarget, Entity))
+			var tx, ty;
+			switch (anchorTarget)
 			{
-				var e:Entity = cast anchorTarget;
-				tx = e.centerX;
-				ty = e.centerY;
+				case Left(v):
+					tx = v.x;
+					ty = v.y;
+					if (Std.is(v, Entity))
+					{
+						var e:Entity = cast v;
+						tx = e.centerX;
+						ty = e.centerY;
+					}
+				case Right(v):
+					tx = v.x;
+					ty = v.y;
 			}
+
 			x = tx - (HXP.width / fullScaleX * anchorX);
 			y = ty - (HXP.height / fullScaleY * anchorY);
 		}

--- a/haxepunk/math/Vector2.hx
+++ b/haxepunk/math/Vector2.hx
@@ -6,7 +6,7 @@ private typedef Position =
 	y:Float
 };
 
-private typedef PositionObj =
+typedef PositionObj =
 {
 	@:isVar var x(get, set):Float;
 	@:isVar var y(get, set):Float;


### PR DESCRIPTION
This is to fix a problem that happened with the anchor system since we've had the Vector2 changes: #596 

Once an instance was converted into a Vector2 its reference was lost and the camera would not follow it.

## The new approach
This adds some congitive complexity that I wish could have been avoided, but I don't think there's anyway to combine Vector2's position and positionObj in a nice way.

So what has been done is using a crude sort of tuple implementation and exposing the PositionObj in Vector2's implementation. Fortunately there's no real impact on the overall structure by doing thaat.

Once we have a tuple in place, and being that there is only two types of data Vector2 uses, we actually have a way to sync to any of the anchorable types and update is working again.

## What's been changed
I've had to change the method signature for anchor to support a crude type of overloading.

It accepts a PositionObj or a Vector2. I originally tried using `OneOf` as a way to accept both and unwrap later but Haxe through compile errors about that approach. It's not exactly a perfect run time tuple.

Once anchor has been called it is stored in an abstract tuple and later unwrapped to grab its position inside of update. The tuple's left contains a PositionObj so this is where we would have access to retrieving entities (like centerX and the like ).

## Possible breaks
Running the tests show that nothing has actually broke, but if there is any reference in HaxePunk to the original Camera.anchorTarget it will be incompatible. So old code that utilized this element would be removed.

This could be easily fixed by making anchorTarget a Vector2 again and wrapping it around the tuple.