### PR TITLE
Add HaxePunk 4.1 Haxe4 compatibility

### DIFF
--- a/haxepunk/Signal.hx
+++ b/haxepunk/Signal.hx
@@ -66,22 +66,43 @@ class Signal2<A, B> extends Signal<A->B->Void>
 /**
  * A collection of named signals, which can be accessed as attributes.
  */
-class Signals implements Dynamic<Signal0>
-{
-	var signals:Map<String, Signal0> = new Map();
+abstract Signals(Map<String, Signal0>) from Map<String, Signal0> {
 
-	public function new() {}
-
-	public inline function exists(field:String) return signals.exists(field);
-
-	public inline function invoke(field:String)
+	public function new()
 	{
-		if (exists(field)) signals[field].invoke();
+		this = new Map<String, Signal0>();
 	}
 
-	public function resolve(field:String):Signal0
+	@:op([]) inline public function arrayRead(field:String)
 	{
-		if (!exists(field)) signals[field] = new Signal0();
-		return signals[field];
+		return this[field];
+	}
+
+	@:op([]) inline public function arrayWrite(field:String, signal:Signal0)
+	{
+		return this[field] = signal;
+	}
+
+	@:op(a.b) inline public function fieldRead(field:String)
+	{
+		return resolve( field);
+	}
+
+	@:op(a.b) inline public function fieldWrite(field:String, signal:Signal0)
+	{
+		return this[field] = signal;
+	}
+
+	public inline function exists(field:String) return this.exists(field);
+	
+	public inline function invoke(field:String)
+	{
+		if (exists(field)) this[field].invoke();
+	}
+
+	public function resolve(field:String)
+	{
+		if (!exists(field)) this[field] = new Signal0();
+		return this[field];
 	}
 }

--- a/haxepunk/Signal.hx
+++ b/haxepunk/Signal.hx
@@ -66,6 +66,7 @@ class Signal2<A, B> extends Signal<A->B->Void>
 /**
  * A collection of named signals, which can be accessed as attributes.
  */
+#if haxe4
 abstract Signals(Map<String, Signal0>) from Map<String, Signal0> {
 
 	public function new()
@@ -106,3 +107,24 @@ abstract Signals(Map<String, Signal0>) from Map<String, Signal0> {
 		return this[field];
 	}
 }
+#else
+class Signals implements Dynamic<Signal0>
+{
+	var signals:Map<String, Signal0> = new Map();
+
+	public function new() {}
+
+	public inline function exists(field:String) return signals.exists(field);
+
+	public inline function invoke(field:String)
+	{
+		if (exists(field)) signals[field].invoke();
+	}
+
+	public function resolve(field:String):Signal0
+	{
+		if (!exists(field)) signals[field] = new Signal0();
+		return signals[field];
+	}
+}
+#end

--- a/haxepunk/graphics/Image.hx
+++ b/haxepunk/graphics/Image.hx
@@ -216,14 +216,14 @@ class Image extends Graphic
 	/**
 	 * The scaled width of the image.
 	 */
-	public var scaledWidth(get, set_scaledWidth):Float;
+	public var scaledWidth(get, set):Float;
 	inline function get_scaledWidth():Float return width * scaleX * scale;
 	inline function set_scaledWidth(w:Float):Float return scaleX = w / scale / width;
 
 	/**
 	 * The scaled height of the image.
 	 */
-	public var scaledHeight(get, set_scaledHeight):Float;
+	public var scaledHeight(get, set):Float;
 	inline function get_scaledHeight():Float return height * scaleY * scale;
 	inline function set_scaledHeight(h:Float):Float return scaleY = h / scale / height;
 

--- a/haxepunk/graphics/text/BitmapFontAtlas.hx
+++ b/haxepunk/graphics/text/BitmapFontAtlas.hx
@@ -1,6 +1,10 @@
 package haxepunk.graphics.text;
 
-import haxe.xml.Fast;
+#if !haxe4
+import haxe.xml.Fast; 
+#else
+import haxe.xml.Access as Fast; 
+#end
 import haxepunk.HXP;
 import haxepunk.assets.AssetLoader;
 import haxepunk.graphics.atlas.AtlasDataType;

--- a/haxepunk/input/Input.hx
+++ b/haxepunk/input/Input.hx
@@ -2,7 +2,9 @@ package haxepunk.input;
 
 import haxepunk.HXP;
 import haxepunk.Signal.Signals;
-#if cpp
+#if haxe4
+import sys.thread.Deque;
+#elseif cpp
 import cpp.vm.Deque;
 #elseif neko
 import neko.vm.Deque;

--- a/haxepunk/masks/Grid.hx
+++ b/haxepunk/masks/Grid.hx
@@ -346,7 +346,11 @@ class Grid extends Hitbox
 	{
 		_point.x = _parent.x + _x - _parent.originX;
 		_point.y = _parent.y + _y - _parent.originY;
+		#if haxe4
+		if (Std.downcast(other, Imagemask) != null) // 'other' inherits from Imagemask
+		#else
 		if (Std.instance(other, Imagemask) != null) // 'other' inherits from Imagemask
+		#end
 		{
 			_rect = cast(other, Imagemask).getBounds();
 			_rect.x += other._parent.x;

--- a/haxepunk/masks/Imagemask.hx
+++ b/haxepunk/masks/Imagemask.hx
@@ -132,7 +132,11 @@ class Imagemask extends Pixelmask
 		rect.x += _parent.x;
 		rect.y += _parent.y;
 
+		#if haxe4
+		if (Std.downcast(other, Imagemask) != null) // 'other' inherits from Imagemask
+		#else
 		if (Std.instance(other, Imagemask) != null) // 'other' inherits from Imagemask
+		#end
 		{
 			_rect = cast(other, Imagemask).getBounds();
 			_rect.x += other._parent.x;

--- a/haxepunk/math/MathUtil.hx
+++ b/haxepunk/math/MathUtil.hx
@@ -6,7 +6,7 @@ package haxepunk.math;
  */
 class MathUtil
 {
-	public static var NUMBER_MAX_VALUE(get_NUMBER_MAX_VALUE,never):Float;
+	public static var NUMBER_MAX_VALUE(get,never):Float;
 	public static inline function get_NUMBER_MAX_VALUE():Float { return 179 * Math.pow(10, 306); } // 1.79e+308
 
 	// Used for rad-to-deg and deg-to-rad conversion.


### PR DESCRIPTION
# Solution for Haxe 3 & 4
This update is completely compatible with Haxe 3.4.1 and Haxe 4.0. This was tested with exports: `Windows, Neko, and HTML` on both Haxe versions. This removes any syntax incompatibilities, reflects API changes across exports, and address that one bad usage of `implements Dynamic<..>` in the Signals class.

NME was tested, but NME does not support 4.0 yet because of syntax incompatibilities.

# Updated Deprecated APIS
- Deques in Haxe 4 are not based on target and we are now suggested to use `system.thread.Deque`

# Name changes
- `haxe.xml.Fast` has been renamed to `Access`. I have double-checked, and the API/usage is _exactly_ the same. 
- `Std.instance` is now `Std.downcast` -> replaced in https://github.com/HaxeFoundation/haxe/pull/8301 (fixed in two files: grid and ImageMask)

# Syntax Changes
- Setters no longer support custom setter names. Usage removed from MathUtil and Image.

# Breaking Changes (implementing Dynamic)
There is only one breaking change, and it is the fact that the Signals class can not be extended. I ended up making it into an abstract which has all of the previous functionality, though. 

I have thought fairly extensively for what it means to not support this, bad, functionality and it is beneficial that we do not try to support `implements Dynamic<T>` going forward. I took into consideration what "Signals" was used for, based on the sparse summary, and it still does the same exact thing that it used to without breaking internal code. 

# Left untouched 
Strings are a bit fuzzy. While I would like to get rid of warnings regarding UTF8 deprecation, I can't say it makes sense for HaxePunk to drop support just yet. Looks like Lime still uses it extensively so we should leave it alone to be consistent with Lime.
