### PR TITLE
Fixed Hitbox and Circle masks colliding with Mask if the entity is offset

### DIFF
--- a/haxepunk/masks/Circle.hx
+++ b/haxepunk/masks/Circle.hx
@@ -36,8 +36,8 @@ class Circle extends Hitbox
 	/** @private Collides against an Entity. */
 	override function collideMask(other:Mask):Bool
 	{
-		var distanceX = Math.abs(_parent.x + _x - other._parent.x - other._parent.width * 0.5),
-			distanceY = Math.abs(_parent.y + _y - other._parent.y - other._parent.height * 0.5);
+		var distanceX = Math.abs(_parent.x + _x - (other._parent.x - other._parent.originX + other._parent.width * 0.5)),
+			distanceY = Math.abs(_parent.y + _y - (other._parent.y - other._parent.originY + other._parent.height * 0.5));
 
 		if (distanceX > other._parent.width * 0.5 + radius
 			|| distanceY > other._parent.height * 0.5 + radius)

--- a/haxepunk/masks/Hitbox.hx
+++ b/haxepunk/masks/Hitbox.hx
@@ -34,8 +34,8 @@ class Hitbox extends Mask
 		var px:Float = _x + _parent.x,
 			py:Float = _y + _parent.y;
 
-		var ox = other._parent.originX + other._parent.x,
-			oy = other._parent.originY + other._parent.y;
+		var ox = other._parent.x - other._parent.originX,
+			oy = other._parent.y - other._parent.originY;
 
 		return px + _width > ox
 			&& py + _height > oy


### PR DESCRIPTION
Collisions were incorrect between an Entity with no mask and an entities with Hitbox or Circle masks if the entity origin is non-zero.