### PR TITLE
Make compatible with latest OpenFL/Lime (option 2)

### DIFF
--- a/backend/lime/haxepunk/App.hx
+++ b/backend/lime/haxepunk/App.hx
@@ -15,12 +15,8 @@ class App extends haxepunk._internal.FlashApp
 		#if (openfl >= "8.0.0")
 		// use the RenderEvent API
 		addEventListener(openfl.events.RenderEvent.RENDER_OPENGL, function(event) {
-			#if (openfl >= "8.9.2")
-			var renderer:openfl._internal.renderer.context3D.Context3DRenderer = cast event.renderer;
-			#else
 			var renderer:openfl.display.OpenGLRenderer = cast event.renderer;
 			haxepunk.graphics.hardware.opengl.GLInternal.gl = renderer.gl;
-			#end
 			haxepunk.graphics.hardware.opengl.GLInternal.renderer = renderer;
 			engine.onRender();
 		});

--- a/backend/lime/haxepunk/graphics/hardware/opengl/GLInternal.hx
+++ b/backend/lime/haxepunk/graphics/hardware/opengl/GLInternal.hx
@@ -6,16 +6,12 @@ import lime.graphics.WebGLRenderContext;
 
 class GLInternal
 {
-	#if (openfl >= "8.9.2")
-	public static var renderer:openfl._internal.renderer.context3D.Context3DRenderer;
-	#elseif (openfl >= "8.0.0")
+	#if (openfl >= "8.0.0")
 	public static var renderer:openfl.display.OpenGLRenderer;
 	public static var gl:WebGLRenderContext;
 	#end
 
-	#if (openfl < "8.9.2")
 	@:access(openfl.display.OpenGLRenderer.__context3D)
-	#end
 	@:access(openfl.display.Stage)
 	@:access(openfl.display3D.textures.TextureBase.__getTexture)
 	@:allow(haxepunk.graphics.hardware.opengl.GLUtils)
@@ -25,13 +21,7 @@ class GLInternal
 		var renderer = @:privateAccess (HXP.app.stage.__renderer).renderSession;
 		#end
 		var bmd:BitmapData = cast texture;
-		GL.bindTexture(GL.TEXTURE_2D, bmd.getTexture(
-		#if (openfl < "8.9.2")
-			renderer.__context3D
-		#else
-			renderer.context3D
-		#end
-		).__getTexture());
+		GL.bindTexture(GL.TEXTURE_2D, bmd.getTexture(renderer.__context3D).__getTexture());
 	}
 
 	public static inline function invalid(object:Dynamic)


### PR DESCRIPTION
Just made HaxePunk compile again and checked for running graphics. Looks like the anticipated workflow for Context3DRenderer got scrapped in OpenFL so I just touched on that. 

Option 2:
In this version I just removed the code that tried working with the OpenLF workflow from 8.9.2. This is an alternative to #632 

# Details
Updated to work with:
OpenFL: 9.0.2
Lime: 7.8.0 
Haxe 4.1.4

Compilation and runtime rendering tested on:
Lime Windows
Lime Neko
Lime Html5
Lime Android

No time to test for Apple devices at the moment since the workflow for those are unfamiliar to me. 
