### PR TITLE
Update to work with current versions of Haxe, OpenFL, and Lime

### DIFF
--- a/backend/flash/haxepunk/Sfx.hx
+++ b/backend/flash/haxepunk/Sfx.hx
@@ -35,7 +35,7 @@ class Sfx
 		if (source == null)
 			throw "Invalid source Sound.";
 
-		if (Std.is(source, String))
+		if (Std.isOfType(source, String))
 		{
 			_sound = AssetLoader.getSound(source);
 			_sounds.set(source, _sound);

--- a/backend/lime/haxepunk/App.hx
+++ b/backend/lime/haxepunk/App.hx
@@ -15,12 +15,8 @@ class App extends haxepunk._internal.FlashApp
 		#if (openfl >= "8.0.0")
 		// use the RenderEvent API
 		addEventListener(openfl.events.RenderEvent.RENDER_OPENGL, function(event) {
-			#if (openfl >= "8.9.2")
-			var renderer:openfl._internal.renderer.context3D.Context3DRenderer = cast event.renderer;
-			#else
 			var renderer:openfl.display.OpenGLRenderer = cast event.renderer;
 			haxepunk.graphics.hardware.opengl.GLInternal.gl = renderer.gl;
-			#end
 			haxepunk.graphics.hardware.opengl.GLInternal.renderer = renderer;
 			engine.onRender();
 		});

--- a/backend/lime/haxepunk/graphics/hardware/opengl/GLInternal.hx
+++ b/backend/lime/haxepunk/graphics/hardware/opengl/GLInternal.hx
@@ -6,16 +6,12 @@ import lime.graphics.WebGLRenderContext;
 
 class GLInternal
 {
-	#if (openfl >= "8.9.2")
-	public static var renderer:openfl._internal.renderer.context3D.Context3DRenderer;
-	#elseif (openfl >= "8.0.0")
+	#if (openfl >= "8.0.0")
 	public static var renderer:openfl.display.OpenGLRenderer;
 	public static var gl:WebGLRenderContext;
 	#end
 
-	#if (openfl < "8.9.2")
 	@:access(openfl.display.OpenGLRenderer.__context3D)
-	#end
 	@:access(openfl.display.Stage)
 	@:access(openfl.display3D.textures.TextureBase.__getTexture)
 	@:allow(haxepunk.graphics.hardware.opengl.GLUtils)
@@ -25,13 +21,7 @@ class GLInternal
 		var renderer = @:privateAccess (HXP.app.stage.__renderer).renderSession;
 		#end
 		var bmd:BitmapData = cast texture;
-		GL.bindTexture(GL.TEXTURE_2D, bmd.getTexture(
-		#if (openfl < "8.9.2")
-			renderer.__context3D
-		#else
-			renderer.context3D
-		#end
-		).__getTexture());
+		GL.bindTexture(GL.TEXTURE_2D, bmd.getTexture(renderer.__context3D).__getTexture());
 	}
 
 	public static inline function invalid(object:Dynamic)

--- a/haxelib.json
+++ b/haxelib.json
@@ -9,7 +9,7 @@
 	"contributors": ["heardtheword", "_ibilon", "bendmorris", "matrefeytontias"],
 	"install": {
 		"munit": "",
-		"openfl": "8.9.1",
-		"lime": "7.6.3"
+		"openfl": "9.1.0",
+		"lime": "7.9.0"
 	}
 }

--- a/haxepunk/Camera.hx
+++ b/haxepunk/Camera.hx
@@ -111,7 +111,7 @@ class Camera
 		{
 			var tx = anchorTarget.x,
 				ty = anchorTarget.y;
-			if (Std.is(anchorTarget, Entity))
+			if (Std.isOfType(anchorTarget, Entity))
 			{
 				var e:Entity = cast anchorTarget;
 				tx = e.centerX;

--- a/haxepunk/Entity.hx
+++ b/haxepunk/Entity.hx
@@ -632,7 +632,7 @@ class Entity extends Tweener
 		{
 			graphic = g;
 		}
-		else if (Std.is(graphic, Graphiclist))
+		else if (Std.isOfType(graphic, Graphiclist))
 		{
 			cast(graphic, Graphiclist).add(g);
 		}
@@ -670,7 +670,7 @@ class Entity extends Tweener
 		#if html5
 		inline function getInt(value:Dynamic, defaultValue:Int = 0):Int
 		{
-			return if (Std.is(value, Int) || Std.is(value, Float))
+			return if (Std.isOfType(value, Int) || Std.isOfType(value, Float))
 				value;
 			else
 				defaultValue;

--- a/haxepunk/HXP.hx
+++ b/haxepunk/HXP.hx
@@ -143,7 +143,7 @@ class HXP
 			throw "Can't choose a random element on an empty array";
 		}
 
-		if (Std.is(objs[0], Array)) // Passed an Array
+		if (Std.isOfType(objs[0], Array)) // Passed an Array
 		{
 			var c:Array<Dynamic> = cast(objs[0], Array<Dynamic>);
 
@@ -390,7 +390,7 @@ class HXP
 			complete:Void -> Void = null,
 			ease:Float -> Float = null,
 			tweener:Tweener = HXP.tweener;
-		if (Std.is(object, Tweener)) tweener = cast(object, Tweener);
+		if (Std.isOfType(object, Tweener)) tweener = cast(object, Tweener);
 		if (options != null)
 		{
 			if (Reflect.hasField(options, "type")) type = options.type;

--- a/haxepunk/Scene.hx
+++ b/haxepunk/Scene.hx
@@ -865,7 +865,7 @@ class Scene extends Tweener
 		for (n in _types.get(type))
 		{
 			dist = (x - n.x) * (x - n.x) + (y - n.y) * (y - n.y);
-			if (dist < nearDist && Std.is(e, classType))
+			if (dist < nearDist && Std.isOfType(e, classType))
 			{
 				nearDist = dist;
 				near = n;
@@ -982,7 +982,7 @@ class Scene extends Tweener
 	{
 		for (e in _update)
 		{
-			if (Std.is(e, c)) return cast e;
+			if (Std.isOfType(e, c)) return cast e;
 		}
 		return null;
 	}
@@ -1085,7 +1085,7 @@ class Scene extends Tweener
 		var n:Int = into.length;
 		for (e in _update)
 		{
-			if (Std.is(e, c))
+			if (Std.isOfType(e, c))
 				into[n++] = cast e;
 		}
 	}

--- a/haxepunk/assets/AssetMacros.hx
+++ b/haxepunk/assets/AssetMacros.hx
@@ -25,7 +25,7 @@ class AssetMacros
 						{
 							// keep this asset cached here too, in case the owning cache is
 							// disposed before this one is
-							Log.debug('adding asset cache reference: ' + ${cache} + ':$id -> ' + otherCache.name + ':$id');
+							Log.debug('adding asset cache reference: ' + ${cache} + ':' + ${id} + ' -> ' + otherCache.name + ':' + ${id});
 							${map}[${id}] = cached;
 							${onRef};
 						}

--- a/haxepunk/graphics/emitter/BaseEmitter.hx
+++ b/haxepunk/graphics/emitter/BaseEmitter.hx
@@ -22,7 +22,7 @@ import haxepunk.math.Vector2;
 	{
 		super();
 		_source = source;
-		_sourceIsImage = Std.is(_source, Image);
+		_sourceIsImage = Std.isOfType(_source, Image);
 		_types = new Map<String, ParticleType>();
 		active = true;
 		particleCount = 0;

--- a/haxepunk/masks/Masklist.hx
+++ b/haxepunk/masks/Masklist.hx
@@ -157,7 +157,7 @@ class Masklist extends Hitbox
 
 		for (m in _masks)
 		{
-			if (Std.is(m, Polygon))
+			if (Std.isOfType(m, Polygon))
 			{
 				p = cast m;
 				if (p != null)

--- a/haxepunk/utils/HaxelibInfo.hx
+++ b/haxepunk/utils/HaxelibInfo.hx
@@ -34,7 +34,7 @@ class HaxelibInfoBuilder
 			var value = Reflect.field(doc, field);
 
 			// Simple String value
-			if (Std.is(value, String))
+			if (Std.isOfType(value, String))
 			{
 				fields.push({
 					name: field,

--- a/tests/src/haxepunk/SceneTest.hx
+++ b/tests/src/haxepunk/SceneTest.hx
@@ -90,7 +90,7 @@ class SceneTest extends TestSuite
 	public function testCreateRecycle()
 	{
 		var e:TestEntity = scene.create(TestEntity, false);
-		Assert.isTrue(Std.is(e, TestEntity));
+		Assert.isTrue(Std.isOfType(e, TestEntity));
 		scene.updateLists();
 		Assert.areEqual(0, countRecycled(scene));
 


### PR DESCRIPTION
Fixes build errors and warnings when using HaxePunk with the most recent versions of Haxe, OpenFL, and Lime (as of the time of this writing, those are 4.2.5, 9.1.0, and 7.9.0, respectively).