### PR TITLE
Fix HashLink target

### DIFF
--- a/haxepunk/graphics/hardware/FrameBuffer.hx
+++ b/haxepunk/graphics/hardware/FrameBuffer.hx
@@ -50,7 +50,7 @@ class FrameBuffer
 		#if (html5 && lime >= "5.0.0")
 		GL.texImage2DWEBGL(GL.TEXTURE_2D, 0, GL.RGBA, width, height, 0, GL.RGBA, GL.UNSIGNED_BYTE);
 		#else
-		GL.texImage2D(GL.TEXTURE_2D, 0, GL.RGBA, width, height, 0, GL.RGBA, GL.UNSIGNED_BYTE, #if ((lime >= "4.0.0") && cpp) 0 #else null #end);
+		GL.texImage2D(GL.TEXTURE_2D, 0, GL.RGBA, width, height, 0, GL.RGBA, GL.UNSIGNED_BYTE, #if ((lime >= "4.0.0") && (cpp || hl)) 0 #else null #end);
 		#end
 
 		GL.texParameteri(GL.TEXTURE_2D, GL.TEXTURE_WRAP_S, GL.CLAMP_TO_EDGE);


### PR DESCRIPTION
`lime test hl` currently throws the following error:

```
HaxePunk/haxepunk/graphics/hardware/FrameBuffer.hx:53: characters 128-132 : On static platforms, null can't be used as basic type lime.utils.DataPointer
```

This fixes the issue, allowing HaxePunk projects to target HashLink.